### PR TITLE
Fix duration format and Anthropic card layout

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -142,16 +142,22 @@ func parseInsightsRange(rangeStr string) time.Duration {
 	}
 }
 
-// formatDuration formats a duration as a human-readable string (e.g., "4h 16m")
+// formatDuration formats a duration as a human-readable string (e.g., "4d 11h" or "3h 16m")
 func formatDuration(d time.Duration) string {
 	if d < 0 {
 		return "Resetting..."
 	}
 
-	hours := int(d.Hours())
+	totalHours := int(d.Hours())
+	days := totalHours / 24
+	hours := totalHours % 24
 	minutes := int(d.Minutes()) % 60
 
-	if hours > 0 && minutes > 0 {
+	if days > 0 && hours > 0 {
+		return fmt.Sprintf("%dd %dh", days, hours)
+	} else if days > 0 {
+		return fmt.Sprintf("%dd %dm", days, minutes)
+	} else if hours > 0 && minutes > 0 {
 		return fmt.Sprintf("%dh %dm", hours, minutes)
 	} else if hours > 0 {
 		return fmt.Sprintf("%dh", hours)

--- a/internal/web/static/style.css
+++ b/internal/web/static/style.css
@@ -565,6 +565,18 @@ button, input, select { font-family: inherit; }
 .quota-card:active { transform: translateY(0); }
 .quota-card.anthropic-card:hover { border-color: var(--accent-anthropic); }
 
+/* Anthropic grid: 2 columns for taller, narrower cards */
+#quota-grid-anthropic {
+  grid-template-columns: repeat(2, 1fr);
+}
+#quota-grid-anthropic .quota-card {
+  padding: 24px 22px 20px;
+}
+/* Animation delays for up to 6 Anthropic cards */
+#quota-grid-anthropic .quota-card:nth-child(4) { animation-delay: 180ms; }
+#quota-grid-anthropic .quota-card:nth-child(5) { animation-delay: 240ms; }
+#quota-grid-anthropic .quota-card:nth-child(6) { animation-delay: 300ms; }
+
 @keyframes cardEntrance {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
@@ -1767,7 +1779,7 @@ button, input, select { font-family: inherit; }
   .app-header { padding: 12px 16px; flex-wrap: wrap; gap: 8px; }
   .brand-text { font-size: 18px; }
   .main-content { padding: 16px; }
-  .quota-grid { grid-template-columns: 1fr; gap: 14px; }
+  .quota-grid, #quota-grid-anthropic { grid-template-columns: 1fr; gap: 14px; }
   .quota-card { padding: 18px; }
   .range-selector { width: 100%; }
   .range-btn { flex: 1; padding: 8px; font-size: 12px; }

--- a/static/style.css
+++ b/static/style.css
@@ -565,6 +565,18 @@ button, input, select { font-family: inherit; }
 .quota-card:active { transform: translateY(0); }
 .quota-card.anthropic-card:hover { border-color: var(--accent-anthropic); }
 
+/* Anthropic grid: 2 columns for taller, narrower cards */
+#quota-grid-anthropic {
+  grid-template-columns: repeat(2, 1fr);
+}
+#quota-grid-anthropic .quota-card {
+  padding: 24px 22px 20px;
+}
+/* Animation delays for up to 6 Anthropic cards */
+#quota-grid-anthropic .quota-card:nth-child(4) { animation-delay: 180ms; }
+#quota-grid-anthropic .quota-card:nth-child(5) { animation-delay: 240ms; }
+#quota-grid-anthropic .quota-card:nth-child(6) { animation-delay: 300ms; }
+
 @keyframes cardEntrance {
   from { opacity: 0; transform: translateY(10px); }
   to { opacity: 1; transform: translateY(0); }
@@ -1767,7 +1779,7 @@ button, input, select { font-family: inherit; }
   .app-header { padding: 12px 16px; flex-wrap: wrap; gap: 8px; }
   .brand-text { font-size: 18px; }
   .main-content { padding: 16px; }
-  .quota-grid { grid-template-columns: 1fr; gap: 14px; }
+  .quota-grid, #quota-grid-anthropic { grid-template-columns: 1fr; gap: 14px; }
   .quota-card { padding: 18px; }
   .range-selector { width: 100%; }
   .range-btn { flex: 1; padding: 8px; font-size: 12px; }


### PR DESCRIPTION
## Summary
- Durations >= 24h now show days (e.g., `4d 11h` instead of `107h 1m`) across all providers and all pages (insights, countdowns, cycle tables, session tables)
- Anthropic quota cards use a 2-column grid layout for taller, narrower cards instead of the wide 3-column layout

## Test plan
- [ ] Verify Anthropic tab shows 2-column card grid on desktop
- [ ] Verify countdown badges show `Xd Yh` format for durations > 24h
- [ ] Verify insight sublabels (exhausts in, resets in) use day format
- [ ] Verify cycle and session table durations use day format
- [ ] Verify mobile view collapses Anthropic cards to single column
- [ ] Verify Synthetic and Z.ai tabs remain 3-column layout