### PR TITLE
fix(ci): switch macOS amd64 release runner to macos-14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
 
   build-macos-amd64:
     needs: test
-    runs-on: macos-13
+    runs-on: macos-14
     name: Build macOS amd64
 
     steps:


### PR DESCRIPTION
## Summary
- switch release workflow macOS amd64 runner from `macos-13` to `macos-14`
- fix immediate cancellation caused by unsupported `macos-13-us-default` configuration

## Test plan
- [x] Triggered release workflow for `v2.11.19` using the updated workflow
- [x] Verified `Build macOS amd64` now starts and completes successfully