### PR TITLE
feat: add OpenRouter provider for credit/usage monitoring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,6 +40,11 @@ COPILOT_TOKEN=
 # Get it from: https://platform.minimax.io (API Keys section)
 MINIMAX_API_KEY=
 
+# --- OpenRouter Configuration ---
+# OpenRouter API key for usage tracking
+# Get it from: https://openrouter.ai/keys
+OPENROUTER_API_KEY=
+
 # --- Polling Configuration ---
 # Interval in seconds between API polls (default: 120)
 # Min: 10, Max: 3600

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ __pycache__/
 
 # Mock server binary
 /mockserver
+onwatch-test

--- a/internal/agent/openrouter_agent.go
+++ b/internal/agent/openrouter_agent.go
@@ -1,0 +1,141 @@
+package agent
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+	"github.com/onllm-dev/onwatch/v2/internal/notify"
+	"github.com/onllm-dev/onwatch/v2/internal/store"
+	"github.com/onllm-dev/onwatch/v2/internal/tracker"
+)
+
+// OpenRouterAgent manages the background polling loop for OpenRouter usage tracking.
+type OpenRouterAgent struct {
+	client       *api.OpenRouterClient
+	store        *store.Store
+	tracker      *tracker.OpenRouterTracker
+	interval     time.Duration
+	logger       *slog.Logger
+	sm           *SessionManager
+	notifier     *notify.NotificationEngine
+	pollingCheck func() bool
+}
+
+// SetPollingCheck sets a function that is called before each poll.
+// If it returns false, the poll is skipped (provider polling disabled).
+func (a *OpenRouterAgent) SetPollingCheck(fn func() bool) {
+	a.pollingCheck = fn
+}
+
+// SetNotifier sets the notification engine for sending alerts.
+func (a *OpenRouterAgent) SetNotifier(n *notify.NotificationEngine) {
+	a.notifier = n
+}
+
+// NewOpenRouterAgent creates a new OpenRouterAgent with the given dependencies.
+func NewOpenRouterAgent(client *api.OpenRouterClient, store *store.Store, tr *tracker.OpenRouterTracker, interval time.Duration, logger *slog.Logger, sm *SessionManager) *OpenRouterAgent {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OpenRouterAgent{
+		client:   client,
+		store:    store,
+		tracker:  tr,
+		interval: interval,
+		logger:   logger,
+		sm:       sm,
+	}
+}
+
+// Run starts the OpenRouter agent's polling loop. It polls immediately,
+// then continues at the configured interval until the context is cancelled.
+func (a *OpenRouterAgent) Run(ctx context.Context) error {
+	a.logger.Info("OpenRouter agent started", "interval", a.interval)
+
+	// Ensure any active session is closed on exit
+	defer func() {
+		if a.sm != nil {
+			a.sm.Close()
+		}
+		a.logger.Info("OpenRouter agent stopped")
+	}()
+
+	// Poll immediately on start
+	a.poll(ctx)
+
+	// Create ticker for periodic polling
+	ticker := time.NewTicker(a.interval)
+	defer ticker.Stop()
+
+	// Main polling loop
+	for {
+		select {
+		case <-ticker.C:
+			a.poll(ctx)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+// poll performs a single OpenRouter poll cycle: fetch usage, store snapshot.
+func (a *OpenRouterAgent) poll(ctx context.Context) {
+	if a.pollingCheck != nil && !a.pollingCheck() {
+		return // polling disabled for this provider
+	}
+
+	resp, err := a.client.FetchUsage(ctx)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		a.logger.Error("Failed to fetch OpenRouter usage", "error", err)
+		return
+	}
+
+	// Convert to snapshot and store
+	now := time.Now().UTC()
+	snapshot := resp.ToSnapshot(now)
+
+	if _, err := a.store.InsertOpenRouterSnapshot(snapshot); err != nil {
+		a.logger.Error("Failed to insert OpenRouter snapshot", "error", err)
+		return
+	}
+
+	// Process with tracker (log error but don't stop)
+	if a.tracker != nil {
+		if err := a.tracker.Process(snapshot); err != nil {
+			a.logger.Error("OpenRouter tracker processing failed", "error", err)
+		}
+	}
+
+	// Check notification thresholds
+	if a.notifier != nil {
+		if snapshot.Limit != nil && *snapshot.Limit > 0 {
+			pct := (snapshot.Usage / *snapshot.Limit) * 100
+			a.notifier.Check(notify.QuotaStatus{
+				Provider:    "openrouter",
+				QuotaKey:    "credits",
+				Utilization: pct,
+				Limit:       *snapshot.Limit,
+			})
+		}
+	}
+
+	// Report to session manager for usage-based session detection
+	if a.sm != nil {
+		a.sm.ReportPoll([]float64{
+			snapshot.Usage,
+		})
+	}
+
+	// Log poll completion
+	a.logger.Info("OpenRouter poll complete",
+		"usage", snapshot.Usage,
+		"usage_daily", snapshot.UsageDaily,
+		"limit", snapshot.Limit,
+		"is_free_tier", snapshot.IsFreeTier,
+	)
+}

--- a/internal/api/openrouter_client.go
+++ b/internal/api/openrouter_client.go
@@ -1,0 +1,166 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// Custom errors for OpenRouter API failures.
+var (
+	ErrOpenRouterUnauthorized  = errors.New("openrouter: unauthorized - invalid API key")
+	ErrOpenRouterRateLimited   = errors.New("openrouter: rate limited")
+	ErrOpenRouterServerError   = errors.New("openrouter: server error")
+	ErrOpenRouterNetworkError  = errors.New("openrouter: network error")
+	ErrOpenRouterInvalidResponse = errors.New("openrouter: invalid response")
+)
+
+// OpenRouterClient is an HTTP client for the OpenRouter API.
+type OpenRouterClient struct {
+	httpClient *http.Client
+	apiKey     string
+	baseURL    string
+	logger     *slog.Logger
+}
+
+// OpenRouterOption configures an OpenRouterClient.
+type OpenRouterOption func(*OpenRouterClient)
+
+// WithOpenRouterBaseURL sets a custom base URL (for testing).
+func WithOpenRouterBaseURL(url string) OpenRouterOption {
+	return func(c *OpenRouterClient) {
+		c.baseURL = url
+	}
+}
+
+// WithOpenRouterTimeout sets a custom timeout (for testing).
+func WithOpenRouterTimeout(timeout time.Duration) OpenRouterOption {
+	return func(c *OpenRouterClient) {
+		c.httpClient.Timeout = timeout
+	}
+}
+
+// NewOpenRouterClient creates a new OpenRouter API client.
+func NewOpenRouterClient(apiKey string, logger *slog.Logger, opts ...OpenRouterOption) *OpenRouterClient {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	client := &OpenRouterClient{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:          1,
+				MaxIdleConnsPerHost:   1,
+				ResponseHeaderTimeout: 30 * time.Second,
+				IdleConnTimeout:       30 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ForceAttemptHTTP2:     true,
+			},
+		},
+		apiKey:  apiKey,
+		baseURL: "https://openrouter.ai",
+		logger:  logger,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
+}
+
+// FetchUsage retrieves the current usage information from the OpenRouter API.
+func (c *OpenRouterClient) FetchUsage(ctx context.Context) (*OpenRouterAuthKeyResponse, error) {
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	url := c.baseURL + "/api/v1/auth/key"
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("openrouter: creating request: %w", err)
+	}
+
+	// Set headers - OpenRouter uses Bearer token authentication
+	req.Header.Set("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("User-Agent", "onwatch/1.0")
+	req.Header.Set("Accept", "application/json")
+
+	// Log request (with redacted API key)
+	c.logger.Debug("fetching OpenRouter usage",
+		"url", url,
+		"api_key", redactOpenRouterAPIKey(c.apiKey),
+	)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		// Check for context cancellation
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+		return nil, fmt.Errorf("%w: %v", ErrOpenRouterNetworkError, err)
+	}
+	defer resp.Body.Close()
+
+	// Log response status
+	c.logger.Debug("OpenRouter usage response received",
+		"status", resp.StatusCode,
+	)
+
+	// Read response body (bounded to 64KB)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return nil, fmt.Errorf("%w: reading body: %v", ErrOpenRouterInvalidResponse, err)
+	}
+
+	// Handle HTTP status codes
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// continue
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, ErrOpenRouterUnauthorized
+	case resp.StatusCode == http.StatusTooManyRequests:
+		return nil, ErrOpenRouterRateLimited
+	case resp.StatusCode >= 500:
+		return nil, fmt.Errorf("%w: status %d", ErrOpenRouterServerError, resp.StatusCode)
+	default:
+		return nil, fmt.Errorf("openrouter: unexpected status code %d", resp.StatusCode)
+	}
+
+	if len(body) == 0 {
+		return nil, fmt.Errorf("%w: empty response body", ErrOpenRouterInvalidResponse)
+	}
+
+	authKeyResp, err := ParseOpenRouterResponse(body)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrOpenRouterInvalidResponse, err)
+	}
+
+	// Log usage info
+	c.logger.Debug("OpenRouter usage fetched successfully",
+		"usage", authKeyResp.Data.Usage,
+		"usage_daily", authKeyResp.Data.UsageDaily,
+		"limit", authKeyResp.Data.Limit,
+		"is_free_tier", authKeyResp.Data.IsFreeTier,
+	)
+
+	return authKeyResp, nil
+}
+
+// redactOpenRouterAPIKey masks the API key for logging.
+func redactOpenRouterAPIKey(key string) string {
+	if key == "" {
+		return "(empty)"
+	}
+
+	if len(key) < 8 {
+		return "***...***"
+	}
+
+	// Show first 4 chars and last 3 chars
+	return key[:4] + "***...***" + key[len(key)-3:]
+}

--- a/internal/api/openrouter_types.go
+++ b/internal/api/openrouter_types.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// OpenRouterAuthKeyData is the inner data from GET /api/v1/auth/key.
+type OpenRouterAuthKeyData struct {
+	Label          string   `json:"label"`
+	Usage          float64  `json:"usage"`
+	Limit          *float64 `json:"limit"`
+	LimitRemaining *float64 `json:"limit_remaining"`
+	IsFreeTier     bool     `json:"is_free_tier"`
+	RateLimit      struct {
+		Requests int    `json:"requests"`
+		Interval string `json:"interval"`
+	} `json:"rate_limit"`
+	UsageDaily   float64 `json:"usage_daily"`
+	UsageWeekly  float64 `json:"usage_weekly"`
+	UsageMonthly float64 `json:"usage_monthly"`
+}
+
+// OpenRouterAuthKeyResponse is the top-level response from GET /api/v1/auth/key.
+type OpenRouterAuthKeyResponse struct {
+	Data OpenRouterAuthKeyData `json:"data"`
+}
+
+// OpenRouterSnapshot is the storage representation (flat, for SQLite).
+type OpenRouterSnapshot struct {
+	ID                int64
+	CapturedAt        time.Time
+	Label             string
+	Usage             float64
+	UsageDaily        float64
+	UsageWeekly       float64
+	UsageMonthly      float64
+	Limit             *float64
+	LimitRemaining    *float64
+	IsFreeTier        bool
+	RateLimitRequests int
+	RateLimitInterval string
+}
+
+// ToSnapshot converts OpenRouterAuthKeyResponse to OpenRouterSnapshot.
+func (r *OpenRouterAuthKeyResponse) ToSnapshot(capturedAt time.Time) *OpenRouterSnapshot {
+	snapshot := &OpenRouterSnapshot{
+		CapturedAt:        capturedAt.UTC(),
+		Label:             r.Data.Label,
+		Usage:             r.Data.Usage,
+		UsageDaily:        r.Data.UsageDaily,
+		UsageWeekly:       r.Data.UsageWeekly,
+		UsageMonthly:      r.Data.UsageMonthly,
+		Limit:             r.Data.Limit,
+		LimitRemaining:    r.Data.LimitRemaining,
+		IsFreeTier:        r.Data.IsFreeTier,
+		RateLimitRequests: r.Data.RateLimit.Requests,
+		RateLimitInterval: r.Data.RateLimit.Interval,
+	}
+
+	return snapshot
+}
+
+// ParseOpenRouterResponse parses an OpenRouter API response from JSON bytes.
+func ParseOpenRouterResponse(data []byte) (*OpenRouterAuthKeyResponse, error) {
+	var resp OpenRouterAuthKeyResponse
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -49,6 +49,9 @@ type Config struct {
 	MiniMaxAPIKey  string // MINIMAX_API_KEY
 	MiniMaxRegion  string // MINIMAX_REGION ( "global" | "cn", default: "global" )
 
+	// OpenRouter provider configuration
+	OpenRouterAPIKey string // OPENROUTER_API_KEY
+
 	// Gemini provider configuration (auto-detected from ~/.gemini/oauth_creds.json or env vars)
 	GeminiEnabled      bool   // true if auto-detected or GEMINI_ENABLED=true
 	GeminiAutoToken    bool   // true if token was auto-detected
@@ -166,6 +169,7 @@ var onwatchEnvKeys = []string{
 	"CODEX_TOKEN",
 	"ANTIGRAVITY_ENABLED",
 	"MINIMAX_API_KEY",
+	"OPENROUTER_API_KEY",
 	"GEMINI_ENABLED",
 	"GEMINI_REFRESH_TOKEN",
 	"GEMINI_ACCESS_TOKEN",
@@ -258,6 +262,9 @@ func loadFromEnvAndFlags(flags *flagValues) (*Config, error) {
 	if cfg.MiniMaxRegion == "" {
 		cfg.MiniMaxRegion = "global"
 	}
+
+	// OpenRouter provider
+	cfg.OpenRouterAPIKey = strings.TrimSpace(os.Getenv("OPENROUTER_API_KEY"))
 
 	// Gemini provider (auto-detected, env vars, or opt-out via GEMINI_ENABLED=false)
 	cfg.GeminiRefreshToken = strings.TrimSpace(os.Getenv("GEMINI_REFRESH_TOKEN"))
@@ -426,6 +433,9 @@ func (c *Config) AvailableProviders() []string {
 	if c.MiniMaxAPIKey != "" {
 		providers = append(providers, "minimax")
 	}
+	if c.OpenRouterAPIKey != "" {
+		providers = append(providers, "openrouter")
+	}
 	if c.GeminiEnabled {
 		providers = append(providers, "gemini")
 	}
@@ -449,6 +459,8 @@ func (c *Config) HasProvider(name string) bool {
 		return c.AntigravityEnabled
 	case "minimax":
 		return c.MiniMaxAPIKey != ""
+	case "openrouter":
+		return c.OpenRouterAPIKey != ""
 	case "gemini":
 		return c.GeminiEnabled
 	}
@@ -477,6 +489,9 @@ func (c *Config) HasMultipleProviders() bool {
 		count++
 	}
 	if c.MiniMaxAPIKey != "" {
+		count++
+	}
+	if c.OpenRouterAPIKey != "" {
 		count++
 	}
 	if c.GeminiEnabled {

--- a/internal/store/openrouter_store.go
+++ b/internal/store/openrouter_store.go
@@ -1,0 +1,272 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+)
+
+// OpenRouterResetCycle represents an OpenRouter usage reset cycle.
+type OpenRouterResetCycle struct {
+	ID         int64
+	QuotaType  string
+	CycleStart time.Time
+	CycleEnd   *time.Time
+	PeakUsage  float64
+	TotalDelta float64
+}
+
+// InsertOpenRouterSnapshot inserts an OpenRouter usage snapshot.
+func (s *Store) InsertOpenRouterSnapshot(snapshot *api.OpenRouterSnapshot) (int64, error) {
+	var limitVal interface{}
+	if snapshot.Limit != nil {
+		limitVal = *snapshot.Limit
+	}
+	var limitRemainingVal interface{}
+	if snapshot.LimitRemaining != nil {
+		limitRemainingVal = *snapshot.LimitRemaining
+	}
+
+	isFreeTier := 0
+	if snapshot.IsFreeTier {
+		isFreeTier = 1
+	}
+
+	result, err := s.db.Exec(
+		`INSERT INTO openrouter_snapshots
+		(captured_at, label, usage, usage_daily, usage_weekly, usage_monthly,
+		 credit_limit, limit_remaining, is_free_tier, rate_limit_requests, rate_limit_interval)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		snapshot.CapturedAt.Format(time.RFC3339Nano),
+		snapshot.Label,
+		snapshot.Usage,
+		snapshot.UsageDaily,
+		snapshot.UsageWeekly,
+		snapshot.UsageMonthly,
+		limitVal,
+		limitRemainingVal,
+		isFreeTier,
+		snapshot.RateLimitRequests,
+		snapshot.RateLimitInterval,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to insert openrouter snapshot: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get last insert ID: %w", err)
+	}
+
+	return id, nil
+}
+
+// QueryLatestOpenRouter returns the most recent OpenRouter snapshot.
+func (s *Store) QueryLatestOpenRouter() (*api.OpenRouterSnapshot, error) {
+	var snapshot api.OpenRouterSnapshot
+	var capturedAt string
+	var creditLimit, limitRemaining sql.NullFloat64
+	var isFreeTier int
+
+	err := s.db.QueryRow(
+		`SELECT id, captured_at, label, usage, usage_daily, usage_weekly, usage_monthly,
+		 credit_limit, limit_remaining, is_free_tier, rate_limit_requests, rate_limit_interval
+		FROM openrouter_snapshots ORDER BY captured_at DESC LIMIT 1`,
+	).Scan(
+		&snapshot.ID, &capturedAt, &snapshot.Label,
+		&snapshot.Usage, &snapshot.UsageDaily, &snapshot.UsageWeekly, &snapshot.UsageMonthly,
+		&creditLimit, &limitRemaining, &isFreeTier,
+		&snapshot.RateLimitRequests, &snapshot.RateLimitInterval,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest openrouter: %w", err)
+	}
+
+	snapshot.CapturedAt, _ = time.Parse(time.RFC3339Nano, capturedAt)
+	if creditLimit.Valid {
+		snapshot.Limit = &creditLimit.Float64
+	}
+	if limitRemaining.Valid {
+		snapshot.LimitRemaining = &limitRemaining.Float64
+	}
+	snapshot.IsFreeTier = isFreeTier != 0
+
+	return &snapshot, nil
+}
+
+// QueryOpenRouterRange returns OpenRouter snapshots within a time range with optional limit.
+func (s *Store) QueryOpenRouterRange(start, end time.Time, limit ...int) ([]*api.OpenRouterSnapshot, error) {
+	query := `SELECT id, captured_at, label, usage, usage_daily, usage_weekly, usage_monthly,
+		 credit_limit, limit_remaining, is_free_tier, rate_limit_requests, rate_limit_interval
+		FROM openrouter_snapshots
+		WHERE captured_at BETWEEN ? AND ?
+		ORDER BY captured_at ASC`
+	args := []interface{}{start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano)}
+	if len(limit) > 0 && limit[0] > 0 {
+		query = `SELECT id, captured_at, label, usage, usage_daily, usage_weekly, usage_monthly,
+			 credit_limit, limit_remaining, is_free_tier, rate_limit_requests, rate_limit_interval
+			FROM (
+				SELECT id, captured_at, label, usage, usage_daily, usage_weekly, usage_monthly,
+					 credit_limit, limit_remaining, is_free_tier, rate_limit_requests, rate_limit_interval
+				FROM openrouter_snapshots
+				WHERE captured_at BETWEEN ? AND ?
+				ORDER BY captured_at DESC
+				LIMIT ?
+			) recent
+			ORDER BY captured_at ASC`
+		args = append(args, limit[0])
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query openrouter range: %w", err)
+	}
+	defer rows.Close()
+
+	var snapshots []*api.OpenRouterSnapshot
+	for rows.Next() {
+		var snapshot api.OpenRouterSnapshot
+		var capturedAt string
+		var creditLimit, limitRemaining sql.NullFloat64
+		var isFreeTier int
+
+		err := rows.Scan(
+			&snapshot.ID, &capturedAt, &snapshot.Label,
+			&snapshot.Usage, &snapshot.UsageDaily, &snapshot.UsageWeekly, &snapshot.UsageMonthly,
+			&creditLimit, &limitRemaining, &isFreeTier,
+			&snapshot.RateLimitRequests, &snapshot.RateLimitInterval,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan openrouter snapshot: %w", err)
+		}
+
+		snapshot.CapturedAt, _ = time.Parse(time.RFC3339Nano, capturedAt)
+		if creditLimit.Valid {
+			snapshot.Limit = &creditLimit.Float64
+		}
+		if limitRemaining.Valid {
+			snapshot.LimitRemaining = &limitRemaining.Float64
+		}
+		snapshot.IsFreeTier = isFreeTier != 0
+
+		snapshots = append(snapshots, &snapshot)
+	}
+
+	return snapshots, rows.Err()
+}
+
+// CreateOpenRouterCycle creates a new OpenRouter reset cycle.
+func (s *Store) CreateOpenRouterCycle(quotaType string, cycleStart time.Time) (int64, error) {
+	result, err := s.db.Exec(
+		`INSERT INTO openrouter_reset_cycles (quota_type, cycle_start) VALUES (?, ?)`,
+		quotaType, cycleStart.Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create openrouter cycle: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get cycle ID: %w", err)
+	}
+
+	return id, nil
+}
+
+// CloseOpenRouterCycle closes an OpenRouter reset cycle with final stats.
+func (s *Store) CloseOpenRouterCycle(quotaType string, cycleEnd time.Time, peakUsage, totalDelta float64) error {
+	_, err := s.db.Exec(
+		`UPDATE openrouter_reset_cycles SET cycle_end = ?, peak_usage = ?, total_delta = ?
+		WHERE quota_type = ? AND cycle_end IS NULL`,
+		cycleEnd.Format(time.RFC3339Nano), peakUsage, totalDelta, quotaType,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to close openrouter cycle: %w", err)
+	}
+	return nil
+}
+
+// UpdateOpenRouterCycle updates the peak and delta for an active OpenRouter cycle.
+func (s *Store) UpdateOpenRouterCycle(quotaType string, peakUsage, totalDelta float64) error {
+	_, err := s.db.Exec(
+		`UPDATE openrouter_reset_cycles SET peak_usage = ?, total_delta = ?
+		WHERE quota_type = ? AND cycle_end IS NULL`,
+		peakUsage, totalDelta, quotaType,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update openrouter cycle: %w", err)
+	}
+	return nil
+}
+
+// QueryActiveOpenRouterCycle returns the active cycle for an OpenRouter quota type.
+func (s *Store) QueryActiveOpenRouterCycle(quotaType string) (*OpenRouterResetCycle, error) {
+	var cycle OpenRouterResetCycle
+	var cycleStart string
+	var cycleEnd sql.NullString
+
+	err := s.db.QueryRow(
+		`SELECT id, quota_type, cycle_start, cycle_end, peak_usage, total_delta
+		FROM openrouter_reset_cycles WHERE quota_type = ? AND cycle_end IS NULL`,
+		quotaType,
+	).Scan(
+		&cycle.ID, &cycle.QuotaType, &cycleStart, &cycleEnd, &cycle.PeakUsage, &cycle.TotalDelta,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query active openrouter cycle: %w", err)
+	}
+
+	cycle.CycleStart, _ = time.Parse(time.RFC3339Nano, cycleStart)
+	if cycleEnd.Valid {
+		endTime, _ := time.Parse(time.RFC3339Nano, cycleEnd.String)
+		cycle.CycleEnd = &endTime
+	}
+
+	return &cycle, nil
+}
+
+// QueryOpenRouterCycleHistory returns completed cycles for an OpenRouter quota type with optional limit.
+func (s *Store) QueryOpenRouterCycleHistory(quotaType string, limit ...int) ([]*OpenRouterResetCycle, error) {
+	query := `SELECT id, quota_type, cycle_start, cycle_end, peak_usage, total_delta
+		FROM openrouter_reset_cycles WHERE quota_type = ? AND cycle_end IS NOT NULL ORDER BY cycle_start DESC`
+	args := []interface{}{quotaType}
+	if len(limit) > 0 && limit[0] > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit[0])
+	}
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query openrouter cycles: %w", err)
+	}
+	defer rows.Close()
+
+	var cycles []*OpenRouterResetCycle
+	for rows.Next() {
+		var cycle OpenRouterResetCycle
+		var cycleStart, cycleEnd string
+
+		err := rows.Scan(
+			&cycle.ID, &cycle.QuotaType, &cycleStart, &cycleEnd, &cycle.PeakUsage, &cycle.TotalDelta,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to scan openrouter cycle: %w", err)
+		}
+
+		cycle.CycleStart, _ = time.Parse(time.RFC3339Nano, cycleStart)
+		endTime, _ := time.Parse(time.RFC3339Nano, cycleEnd)
+		cycle.CycleEnd = &endTime
+
+		cycles = append(cycles, &cycle)
+	}
+
+	return cycles, rows.Err()
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -593,6 +593,36 @@ func (s *Store) createTables() error {
 		CREATE INDEX IF NOT EXISTS idx_gemini_quota_values_model ON gemini_quota_values(model_id);
 		CREATE INDEX IF NOT EXISTS idx_gemini_cycles_model_start ON gemini_reset_cycles(model_id, cycle_start);
 		CREATE INDEX IF NOT EXISTS idx_gemini_cycles_model_active ON gemini_reset_cycles(model_id) WHERE cycle_end IS NULL;
+
+		-- OpenRouter-specific tables
+		CREATE TABLE IF NOT EXISTS openrouter_snapshots (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			captured_at TEXT NOT NULL,
+			label TEXT NOT NULL DEFAULT '',
+			usage REAL NOT NULL DEFAULT 0,
+			usage_daily REAL NOT NULL DEFAULT 0,
+			usage_weekly REAL NOT NULL DEFAULT 0,
+			usage_monthly REAL NOT NULL DEFAULT 0,
+			credit_limit REAL,
+			limit_remaining REAL,
+			is_free_tier INTEGER NOT NULL DEFAULT 0,
+			rate_limit_requests INTEGER NOT NULL DEFAULT 0,
+			rate_limit_interval TEXT NOT NULL DEFAULT ''
+		);
+
+		CREATE TABLE IF NOT EXISTS openrouter_reset_cycles (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			quota_type TEXT NOT NULL,
+			cycle_start TEXT NOT NULL,
+			cycle_end TEXT,
+			peak_usage REAL NOT NULL DEFAULT 0,
+			total_delta REAL NOT NULL DEFAULT 0
+		);
+
+		-- OpenRouter indexes
+		CREATE INDEX IF NOT EXISTS idx_openrouter_snapshots_captured ON openrouter_snapshots(captured_at);
+		CREATE INDEX IF NOT EXISTS idx_openrouter_cycles_type_start ON openrouter_reset_cycles(quota_type, cycle_start);
+		CREATE INDEX IF NOT EXISTS idx_openrouter_cycles_type_active ON openrouter_reset_cycles(quota_type, cycle_end) WHERE cycle_end IS NULL;
 	`
 
 	if _, err := s.db.Exec(schema); err != nil {

--- a/internal/tracker/openrouter_tracker.go
+++ b/internal/tracker/openrouter_tracker.go
@@ -1,0 +1,215 @@
+package tracker
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+	"github.com/onllm-dev/onwatch/v2/internal/store"
+)
+
+// OpenRouterTracker manages reset cycle detection and usage calculation for OpenRouter.
+type OpenRouterTracker struct {
+	store  *store.Store
+	logger *slog.Logger
+
+	// Cache last seen values for delta calculation
+	lastUsage     float64
+	hasLastValues bool
+
+	onReset func(quotaName string) // called when a usage reset is detected
+}
+
+// SetOnReset registers a callback that is invoked when a usage reset is detected.
+func (t *OpenRouterTracker) SetOnReset(fn func(string)) {
+	t.onReset = fn
+}
+
+// OpenRouterSummary contains computed usage statistics for OpenRouter.
+type OpenRouterSummary struct {
+	QuotaType       string
+	CurrentUsage    float64
+	CurrentLimit    float64  // 0 if no limit (unlimited)
+	LimitRemaining  *float64 // nil if no limit
+	UsagePercent    float64
+	IsFreeTier      bool
+	CurrentRate     float64 // per hour
+	ProjectedUsage  float64
+	CompletedCycles int
+	AvgPerCycle     float64
+	PeakCycle       float64
+	TotalTracked    float64
+	TrackingSince   time.Time
+}
+
+// NewOpenRouterTracker creates a new OpenRouterTracker.
+func NewOpenRouterTracker(store *store.Store, logger *slog.Logger) *OpenRouterTracker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OpenRouterTracker{
+		store:  store,
+		logger: logger,
+	}
+}
+
+// Process compares current snapshot with previous, detects resets, updates cycles.
+func (t *OpenRouterTracker) Process(snapshot *api.OpenRouterSnapshot) error {
+	if err := t.processCredits(snapshot); err != nil {
+		return fmt.Errorf("openrouter tracker: credits: %w", err)
+	}
+
+	t.hasLastValues = true
+	return nil
+}
+
+// processCredits tracks the credits/usage quota cycle.
+// Reset detection: usage drops significantly (indicates a new billing period or credit top-up).
+func (t *OpenRouterTracker) processCredits(snapshot *api.OpenRouterSnapshot) error {
+	quotaType := "credits"
+	currentUsage := snapshot.Usage
+
+	cycle, err := t.store.QueryActiveOpenRouterCycle(quotaType)
+	if err != nil {
+		return fmt.Errorf("failed to query active cycle: %w", err)
+	}
+
+	if cycle == nil {
+		// First snapshot - create new cycle
+		_, err := t.store.CreateOpenRouterCycle(quotaType, snapshot.CapturedAt)
+		if err != nil {
+			return fmt.Errorf("failed to create cycle: %w", err)
+		}
+		if err := t.store.UpdateOpenRouterCycle(quotaType, currentUsage, 0); err != nil {
+			return fmt.Errorf("failed to set initial peak: %w", err)
+		}
+		t.lastUsage = currentUsage
+		t.logger.Info("Created new OpenRouter credits cycle",
+			"initialUsage", currentUsage,
+		)
+		return nil
+	}
+
+	// Check for reset: detect significant drop in usage value
+	resetDetected := false
+	if t.hasLastValues && t.lastUsage > 0 && currentUsage < t.lastUsage*0.5 {
+		resetDetected = true
+	}
+
+	if resetDetected {
+		// Close old cycle with final stats
+		if err := t.store.CloseOpenRouterCycle(quotaType, snapshot.CapturedAt, cycle.PeakUsage, cycle.TotalDelta); err != nil {
+			return fmt.Errorf("failed to close cycle: %w", err)
+		}
+
+		// Create new cycle
+		if _, err := t.store.CreateOpenRouterCycle(quotaType, snapshot.CapturedAt); err != nil {
+			return fmt.Errorf("failed to create new cycle: %w", err)
+		}
+		if err := t.store.UpdateOpenRouterCycle(quotaType, currentUsage, 0); err != nil {
+			return fmt.Errorf("failed to set initial peak: %w", err)
+		}
+
+		t.lastUsage = currentUsage
+		t.logger.Info("Detected OpenRouter credits reset",
+			"lastUsage", t.lastUsage,
+			"newUsage", currentUsage,
+			"totalDelta", cycle.TotalDelta,
+		)
+		if t.onReset != nil {
+			t.onReset(quotaType)
+		}
+		return nil
+	}
+
+	// Same cycle - update stats
+	if t.hasLastValues {
+		delta := currentUsage - t.lastUsage
+		if delta > 0 {
+			cycle.TotalDelta += delta
+		}
+		if currentUsage > cycle.PeakUsage {
+			cycle.PeakUsage = currentUsage
+		}
+		if err := t.store.UpdateOpenRouterCycle(quotaType, cycle.PeakUsage, cycle.TotalDelta); err != nil {
+			return fmt.Errorf("failed to update cycle: %w", err)
+		}
+	} else {
+		// First snapshot after restart - update peak if higher
+		if currentUsage > cycle.PeakUsage {
+			cycle.PeakUsage = currentUsage
+			if err := t.store.UpdateOpenRouterCycle(quotaType, cycle.PeakUsage, cycle.TotalDelta); err != nil {
+				return fmt.Errorf("failed to update cycle: %w", err)
+			}
+		}
+	}
+
+	t.lastUsage = currentUsage
+	return nil
+}
+
+// UsageSummary returns computed stats for OpenRouter usage.
+func (t *OpenRouterTracker) UsageSummary() (*OpenRouterSummary, error) {
+	quotaType := "credits"
+
+	activeCycle, err := t.store.QueryActiveOpenRouterCycle(quotaType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query active cycle: %w", err)
+	}
+
+	history, err := t.store.QueryOpenRouterCycleHistory(quotaType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query cycle history: %w", err)
+	}
+
+	summary := &OpenRouterSummary{
+		QuotaType:       quotaType,
+		CompletedCycles: len(history),
+	}
+
+	// Calculate stats from completed cycles
+	if len(history) > 0 {
+		var totalDelta float64
+		summary.TrackingSince = history[len(history)-1].CycleStart // oldest cycle (history is DESC)
+
+		for _, cycle := range history {
+			totalDelta += cycle.TotalDelta
+			if cycle.TotalDelta > summary.PeakCycle {
+				summary.PeakCycle = cycle.TotalDelta
+			}
+		}
+		summary.AvgPerCycle = totalDelta / float64(len(history))
+		summary.TotalTracked = totalDelta
+	}
+
+	// Add active cycle data
+	if activeCycle != nil {
+		summary.TotalTracked += activeCycle.TotalDelta
+
+		// Get latest snapshot for current usage
+		latest, err := t.store.QueryLatestOpenRouter()
+		if err != nil {
+			return nil, fmt.Errorf("failed to query latest: %w", err)
+		}
+
+		if latest != nil {
+			summary.CurrentUsage = latest.Usage
+			summary.IsFreeTier = latest.IsFreeTier
+			summary.LimitRemaining = latest.LimitRemaining
+
+			if latest.Limit != nil && *latest.Limit > 0 {
+				summary.CurrentLimit = *latest.Limit
+				summary.UsagePercent = (latest.Usage / *latest.Limit) * 100
+			}
+
+			// Calculate rate from active cycle timing
+			elapsed := time.Since(activeCycle.CycleStart)
+			if elapsed.Hours() > 0 && summary.CurrentUsage > 0 {
+				summary.CurrentRate = summary.CurrentUsage / elapsed.Hours()
+			}
+		}
+	}
+
+	return summary, nil
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -82,6 +82,7 @@ type Handler struct {
 	antigravityTracker *tracker.AntigravityTracker
 	minimaxTracker     *tracker.MiniMaxTracker
 	geminiTracker      *tracker.GeminiTracker
+	openrouterTracker  *tracker.OpenRouterTracker
 	updater            *update.Updater
 	notifier           Notifier
 	agentManager       ProviderAgentController
@@ -336,6 +337,11 @@ func (h *Handler) SetMiniMaxTracker(t *tracker.MiniMaxTracker) {
 // SetGeminiTracker sets the Gemini tracker for usage summary enrichment.
 func (h *Handler) SetGeminiTracker(t *tracker.GeminiTracker) {
 	h.geminiTracker = t
+}
+
+// SetOpenRouterTracker sets the OpenRouter tracker for usage summary enrichment.
+func (h *Handler) SetOpenRouterTracker(t *tracker.OpenRouterTracker) {
+	h.openrouterTracker = t
 }
 
 // SetAgentManager sets provider agent lifecycle controller.
@@ -622,6 +628,7 @@ func providerCatalog() []providerCatalogItem {
 		{Key: "codex", Name: "Codex", Description: "OpenAI Codex usage tracking", AutoDetectable: true},
 		{Key: "antigravity", Name: "Antigravity", Description: "Antigravity model usage tracking", AutoDetectable: true},
 		{Key: "minimax", Name: "MiniMax", Description: "MiniMax Coding Plan usage tracking"},
+		{Key: "openrouter", Name: "OpenRouter", Description: "OpenRouter credits usage tracking"},
 		{Key: "gemini", Name: "Gemini", Description: "Google Gemini CLI quota tracking", AutoDetectable: true},
 	}
 }
@@ -663,6 +670,8 @@ func (h *Handler) isProviderConfigured(provider string) bool {
 		return h.detectAntigravityConnection() != nil
 	case "minimax":
 		return strings.TrimSpace(h.config.MiniMaxAPIKey) != ""
+	case "openrouter":
+		return strings.TrimSpace(h.config.OpenRouterAPIKey) != ""
 	case "gemini":
 		return h.config.GeminiEnabled
 	default:
@@ -788,6 +797,7 @@ func applyProviderConfig(dst, src *config.Config) {
 	dst.AntigravityCSRFToken = src.AntigravityCSRFToken
 	dst.AntigravityEnabled = src.AntigravityEnabled
 	dst.MiniMaxAPIKey = src.MiniMaxAPIKey
+	dst.OpenRouterAPIKey = src.OpenRouterAPIKey
 	dst.GeminiEnabled = src.GeminiEnabled
 	dst.GeminiAutoToken = src.GeminiAutoToken
 }
@@ -1044,6 +1054,8 @@ func (h *Handler) Dashboard(w http.ResponseWriter, r *http.Request) {
 	hasCodex := hasVisibleProvider("codex")
 	hasAntigravity := hasVisibleProvider("antigravity")
 	hasMiniMax := hasVisibleProvider("minimax")
+	hasOpenRouter := hasVisibleProvider("openrouter")
+	_ = hasOpenRouter // used by template if needed
 	data := map[string]interface{}{
 		"Title":           "Dashboard",
 		"Providers":       providers,
@@ -1092,6 +1104,8 @@ func (h *Handler) Current(w http.ResponseWriter, r *http.Request) {
 		h.currentAntigravity(w, r)
 	case "minimax":
 		h.currentMiniMax(w, r)
+	case "openrouter":
+		h.currentOpenRouter(w, r)
 	case "gemini":
 		h.currentGemini(w, r)
 	default:
@@ -1140,6 +1154,9 @@ func (h *Handler) currentBoth(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.config.HasProvider("minimax") && providerTelemetryEnabled(visibility, "minimax") {
 		response["minimax"] = h.buildMiniMaxCurrent()
+	}
+	if h.config.HasProvider("openrouter") && providerTelemetryEnabled(visibility, "openrouter") {
+		response["openrouter"] = h.buildOpenRouterCurrent()
 	}
 	if h.config.HasProvider("gemini") && providerTelemetryEnabled(visibility, "gemini") {
 		response["gemini"] = h.buildGeminiCurrent()
@@ -1478,6 +1495,8 @@ func (h *Handler) History(w http.ResponseWriter, r *http.Request) {
 		h.historyAntigravity(w, r)
 	case "minimax":
 		h.historyMiniMax(w, r)
+	case "openrouter":
+		h.historyOpenRouter(w, r)
 	case "gemini":
 		h.historyGemini(w, r)
 	default:
@@ -1704,6 +1723,34 @@ func (h *Handler) historyBoth(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	if h.config.HasProvider("openrouter") && providerTelemetryEnabled(visibility, "openrouter") && h.store != nil {
+		snapshots, err := h.store.QueryOpenRouterRange(start, now)
+		if err == nil {
+			step := downsampleStep(len(snapshots), maxChartPoints)
+			last := len(snapshots) - 1
+			orData := make([]map[string]interface{}, 0, min(len(snapshots), maxChartPoints))
+			for i, s := range snapshots {
+				if step > 1 && i != 0 && i != last && i%step != 0 {
+					continue
+				}
+				entry := map[string]interface{}{
+					"capturedAt": s.CapturedAt.Format(time.RFC3339),
+					"usage":      s.Usage,
+					"usageDaily": s.UsageDaily,
+					"isFreeTier": s.IsFreeTier,
+				}
+				if s.Limit != nil {
+					entry["limit"] = *s.Limit
+					if *s.Limit > 0 {
+						entry["percent"] = (s.Usage / *s.Limit) * 100
+					}
+				}
+				orData = append(orData, entry)
+			}
+			response["openrouter"] = orData
+		}
+	}
+
 	if h.config.HasProvider("gemini") && providerTelemetryEnabled(visibility, "gemini") && h.store != nil {
 		snapshots, err := h.store.QueryGeminiRange(start, now)
 		if err == nil {
@@ -1848,6 +1895,464 @@ func (h *Handler) historyZai(w http.ResponseWriter, r *http.Request) {
 	respondJSON(w, http.StatusOK, response)
 }
 
+// currentOpenRouter returns OpenRouter credits status
+func (h *Handler) currentOpenRouter(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, h.buildOpenRouterCurrent())
+}
+
+// buildOpenRouterCurrent builds the OpenRouter current credits response map.
+func (h *Handler) buildOpenRouterCurrent() map[string]interface{} {
+	now := time.Now().UTC()
+	response := map[string]interface{}{
+		"capturedAt": now.Format(time.RFC3339),
+		"credits": map[string]interface{}{
+			"name":        "Credits",
+			"description": "OpenRouter API credits usage",
+			"usage":       0.0,
+			"limit":       nil,
+			"remaining":   nil,
+			"percent":     0.0,
+			"isFreeTier":  false,
+			"rate":        0.0,
+			"projected":   0.0,
+		},
+	}
+
+	if h.store != nil {
+		latest, err := h.store.QueryLatestOpenRouter()
+		if err != nil {
+			h.logger.Error("failed to query latest OpenRouter snapshot", "error", err)
+			return response
+		}
+
+		if latest != nil {
+			response["capturedAt"] = latest.CapturedAt.Format(time.RFC3339)
+			credits := map[string]interface{}{
+				"name":        "Credits",
+				"description": "OpenRouter API credits usage",
+				"usage":       latest.Usage,
+				"usageDaily":  latest.UsageDaily,
+				"limit":       nil,
+				"remaining":   nil,
+				"percent":     0.0,
+				"isFreeTier":  latest.IsFreeTier,
+				"rate":        0.0,
+				"projected":   0.0,
+			}
+			if latest.Limit != nil && *latest.Limit > 0 {
+				credits["limit"] = *latest.Limit
+				credits["percent"] = (latest.Usage / *latest.Limit) * 100
+			}
+			if latest.LimitRemaining != nil {
+				credits["remaining"] = *latest.LimitRemaining
+			}
+
+			// Enrich with tracker data
+			if h.openrouterTracker != nil {
+				if summary, err := h.openrouterTracker.UsageSummary(); err == nil && summary != nil {
+					credits["rate"] = summary.CurrentRate
+					credits["projected"] = summary.ProjectedUsage
+					credits["completedCycles"] = summary.CompletedCycles
+					credits["avgPerCycle"] = summary.AvgPerCycle
+					credits["peakCycle"] = summary.PeakCycle
+					credits["totalTracked"] = summary.TotalTracked
+					if !summary.TrackingSince.IsZero() {
+						credits["trackingSince"] = summary.TrackingSince.Format(time.RFC3339)
+					}
+				}
+			}
+
+			response["credits"] = credits
+		}
+	}
+
+	return response
+}
+
+// historyOpenRouter returns OpenRouter usage history
+func (h *Handler) historyOpenRouter(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		respondJSON(w, http.StatusOK, []interface{}{})
+		return
+	}
+
+	rangeStr := r.URL.Query().Get("range")
+	duration, err := parseTimeRange(rangeStr)
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	start := now.Add(-duration)
+	end := now
+
+	snapshots, err := h.store.QueryOpenRouterRange(start, end)
+	if err != nil {
+		h.logger.Error("failed to query OpenRouter history", "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to query history")
+		return
+	}
+
+	step := downsampleStep(len(snapshots), maxChartPoints)
+	last := len(snapshots) - 1
+	histResp := make([]map[string]interface{}, 0, min(len(snapshots), maxChartPoints))
+	for i, snapshot := range snapshots {
+		if step > 1 && i != 0 && i != last && i%step != 0 {
+			continue
+		}
+		entry := map[string]interface{}{
+			"capturedAt": snapshot.CapturedAt.Format(time.RFC3339),
+			"usage":      snapshot.Usage,
+			"usageDaily": snapshot.UsageDaily,
+			"isFreeTier": snapshot.IsFreeTier,
+		}
+		if snapshot.Limit != nil {
+			entry["limit"] = *snapshot.Limit
+			if *snapshot.Limit > 0 {
+				entry["percent"] = (snapshot.Usage / *snapshot.Limit) * 100
+			}
+		}
+		if snapshot.LimitRemaining != nil {
+			entry["remaining"] = *snapshot.LimitRemaining
+		}
+		histResp = append(histResp, entry)
+	}
+
+	respondJSON(w, http.StatusOK, histResp)
+}
+
+// cyclesOpenRouter returns OpenRouter cycle data
+func (h *Handler) cyclesOpenRouter(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		respondJSON(w, http.StatusOK, []interface{}{})
+		return
+	}
+
+	quotaType := "credits"
+	response := make([]map[string]interface{}, 0)
+
+	active, err := h.store.QueryActiveOpenRouterCycle(quotaType)
+	if err != nil {
+		h.logger.Error("failed to query active OpenRouter cycle", "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to query cycles")
+		return
+	}
+
+	if active != nil {
+		response = append(response, openrouterCycleToMap(active))
+	}
+
+	history, err := h.store.QueryOpenRouterCycleHistory(quotaType, 200)
+	if err != nil {
+		h.logger.Error("failed to query OpenRouter cycle history", "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to query cycles")
+		return
+	}
+
+	for _, cycle := range history {
+		response = append(response, openrouterCycleToMap(cycle))
+	}
+
+	respondJSON(w, http.StatusOK, response)
+}
+
+func openrouterCycleToMap(cycle *store.OpenRouterResetCycle) map[string]interface{} {
+	result := map[string]interface{}{
+		"id":           cycle.ID,
+		"quotaType":    cycle.QuotaType,
+		"cycleStart":   cycle.CycleStart.Format(time.RFC3339),
+		"cycleEnd":     nil,
+		"peakRequests": cycle.PeakUsage,
+		"totalDelta":   cycle.TotalDelta,
+	}
+
+	if cycle.CycleEnd != nil {
+		result["cycleEnd"] = cycle.CycleEnd.Format(time.RFC3339)
+	}
+
+	return result
+}
+
+// summaryOpenRouter returns OpenRouter usage summary
+func (h *Handler) summaryOpenRouter(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, h.buildOpenRouterSummaryMap())
+}
+
+// buildOpenRouterSummaryMap builds the OpenRouter summary response.
+func (h *Handler) buildOpenRouterSummaryMap() map[string]interface{} {
+	response := map[string]interface{}{
+		"credits": map[string]interface{}{
+			"quotaType":       "credits",
+			"currentUsage":    0.0,
+			"currentLimit":    0.0,
+			"usagePercent":    0.0,
+			"currentRate":     0.0,
+			"projectedUsage":  0.0,
+			"completedCycles": 0,
+			"avgPerCycle":     0.0,
+			"peakCycle":       0.0,
+			"totalTracked":    0.0,
+			"trackingSince":   nil,
+		},
+	}
+
+	if h.openrouterTracker != nil {
+		if summary, err := h.openrouterTracker.UsageSummary(); err == nil && summary != nil {
+			response["credits"] = map[string]interface{}{
+				"quotaType":       summary.QuotaType,
+				"currentUsage":    summary.CurrentUsage,
+				"currentLimit":    summary.CurrentLimit,
+				"usagePercent":    summary.UsagePercent,
+				"currentRate":     summary.CurrentRate,
+				"projectedUsage":  summary.ProjectedUsage,
+				"completedCycles": summary.CompletedCycles,
+				"avgPerCycle":     summary.AvgPerCycle,
+				"peakCycle":       summary.PeakCycle,
+				"totalTracked":    summary.TotalTracked,
+				"trackingSince":   nil,
+				"isFreeTier":      summary.IsFreeTier,
+			}
+			if !summary.TrackingSince.IsZero() {
+				response["credits"].(map[string]interface{})["trackingSince"] = summary.TrackingSince.Format(time.RFC3339)
+			}
+		}
+		return response
+	}
+
+	// Fallback to snapshot-only summary
+	if h.store != nil {
+		latest, err := h.store.QueryLatestOpenRouter()
+		if err != nil {
+			h.logger.Error("failed to query latest OpenRouter snapshot", "error", err)
+			return response
+		}
+		if latest != nil {
+			creditsMap := response["credits"].(map[string]interface{})
+			creditsMap["currentUsage"] = latest.Usage
+			if latest.Limit != nil && *latest.Limit > 0 {
+				creditsMap["currentLimit"] = *latest.Limit
+				creditsMap["usagePercent"] = (latest.Usage / *latest.Limit) * 100
+			}
+		}
+	}
+
+	return response
+}
+
+// insightsOpenRouter returns OpenRouter insights
+func (h *Handler) insightsOpenRouter(w http.ResponseWriter, r *http.Request, rangeDur time.Duration) {
+	hidden := h.getHiddenInsightKeys()
+	respondJSON(w, http.StatusOK, h.buildOpenRouterInsights(hidden))
+}
+
+// buildOpenRouterInsights builds the OpenRouter insights response.
+func (h *Handler) buildOpenRouterInsights(hidden map[string]bool) insightsResponse {
+	resp := insightsResponse{Stats: []insightStat{}, Insights: []insightItem{}}
+
+	if h.store == nil {
+		return resp
+	}
+
+	latest, err := h.store.QueryLatestOpenRouter()
+	if err != nil {
+		h.logger.Error("failed to query OpenRouter data for insights", "error", err)
+		return resp
+	}
+
+	if latest == nil {
+		resp.Insights = append(resp.Insights, insightItem{
+			Type: "info", Severity: "info",
+			Title: "Getting Started",
+			Desc:  "Keep onWatch running to collect OpenRouter usage data. Insights appear after a few snapshots.",
+		})
+		return resp
+	}
+
+	now := time.Now().UTC()
+
+	// Stats cards
+	if !hidden["usage"] {
+		usageLabel := fmt.Sprintf("$%.4f", latest.Usage)
+		resp.Stats = append(resp.Stats, insightStat{
+			Label: "Total Usage", Value: usageLabel, Sublabel: "credits consumed",
+		})
+	}
+
+	if !hidden["daily_usage"] {
+		dailyLabel := fmt.Sprintf("$%.4f", latest.UsageDaily)
+		resp.Stats = append(resp.Stats, insightStat{
+			Label: "Daily Usage", Value: dailyLabel, Sublabel: "today",
+		})
+	}
+
+	if latest.Limit != nil && *latest.Limit > 0 && !hidden["remaining"] {
+		remaining := *latest.Limit - latest.Usage
+		if remaining < 0 {
+			remaining = 0
+		}
+		pct := (latest.Usage / *latest.Limit) * 100
+		resp.Stats = append(resp.Stats, insightStat{
+			Label: "Remaining", Value: fmt.Sprintf("$%.4f", remaining), Sublabel: fmt.Sprintf("%.1f%% used", pct),
+		})
+	}
+
+	if h.openrouterTracker != nil {
+		if summary, err := h.openrouterTracker.UsageSummary(); err == nil && summary != nil {
+			if !hidden["rate"] && summary.CurrentRate > 0 {
+				resp.Stats = append(resp.Stats, insightStat{
+					Label: "Usage Rate", Value: fmt.Sprintf("$%.4f/hr", summary.CurrentRate), Sublabel: "current rate",
+				})
+			}
+		}
+	}
+
+	// Insights
+	if latest.IsFreeTier && !hidden["free_tier"] {
+		resp.Insights = append(resp.Insights, insightItem{
+			Type: "info", Severity: "info",
+			Title: "Free Tier",
+			Desc:  "You're on the OpenRouter free tier. Some models may have limited access.",
+		})
+	}
+
+	if latest.Limit != nil && *latest.Limit > 0 {
+		pct := (latest.Usage / *latest.Limit) * 100
+		if pct >= 90 && !hidden["high_usage"] {
+			resp.Insights = append(resp.Insights, insightItem{
+				Type: "warning", Severity: "high",
+				Title: "High Credit Usage",
+				Desc:  fmt.Sprintf("You've used %.1f%% of your $%.2f credit limit.", pct, *latest.Limit),
+			})
+		} else if pct >= 75 && !hidden["moderate_usage"] {
+			resp.Insights = append(resp.Insights, insightItem{
+				Type: "info", Severity: "medium",
+				Title: "Moderate Credit Usage",
+				Desc:  fmt.Sprintf("You've used %.1f%% of your $%.2f credit limit.", pct, *latest.Limit),
+			})
+		}
+	}
+
+	_ = now // for potential future time-based insights
+
+	return resp
+}
+
+// cycleOverviewOpenRouter returns OpenRouter cycle overview.
+func (h *Handler) cycleOverviewOpenRouter(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		respondJSON(w, http.StatusOK, map[string]interface{}{"cycles": []interface{}{}})
+		return
+	}
+
+	quotaType := "credits"
+	var cycles []map[string]interface{}
+
+	if active, err := h.store.QueryActiveOpenRouterCycle(quotaType); err == nil && active != nil {
+		cycles = append(cycles, openrouterCycleToMap(active))
+	}
+	if history, err := h.store.QueryOpenRouterCycleHistory(quotaType, 50); err == nil {
+		for _, c := range history {
+			cycles = append(cycles, openrouterCycleToMap(c))
+		}
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"groupBy":    quotaType,
+		"provider":   "openrouter",
+		"quotaNames": []string{"credits"},
+		"cycles":     cycles,
+	})
+}
+
+// loggingHistoryOpenRouter returns OpenRouter polling history.
+func (h *Handler) loggingHistoryOpenRouter(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		respondJSON(w, http.StatusOK, map[string]interface{}{"provider": "openrouter", "quotaNames": []string{}, "logs": []interface{}{}})
+		return
+	}
+
+	start, end, limit := h.loggingHistoryRangeAndLimit(r)
+
+	snapshots, err := h.store.QueryOpenRouterRange(start, end, limit)
+	if err != nil {
+		h.logger.Error("failed to query OpenRouter logging history", "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to query history")
+		return
+	}
+
+	quotaNames := []string{"credits"}
+	type quotaVal struct {
+		Name     string
+		Value    float64
+		Limit    float64
+		Percent  float64
+		HasValue bool
+		HasLimit bool
+	}
+
+	capturedAt := make([]string, 0, len(snapshots))
+	ids := make([]int64, 0, len(snapshots))
+	series := make([]map[string]quotaVal, 0, len(snapshots))
+
+	for _, snap := range snapshots {
+		capturedAt = append(capturedAt, snap.CapturedAt.Format(time.RFC3339))
+		ids = append(ids, snap.ID)
+
+		limitVal := 0.0
+		pct := 0.0
+		hasLimit := false
+		if snap.Limit != nil && *snap.Limit > 0 {
+			limitVal = *snap.Limit
+			pct = (snap.Usage / *snap.Limit) * 100
+			hasLimit = true
+		}
+
+		row := map[string]quotaVal{
+			"credits": {
+				Name:     "credits",
+				Value:    snap.Usage,
+				Limit:    limitVal,
+				Percent:  pct,
+				HasValue: true,
+				HasLimit: hasLimit,
+			},
+		}
+		series = append(series, row)
+	}
+
+	// Build logs manually since loggingHistoryRowsFromSnapshots expects specific types
+	logs := make([]map[string]interface{}, 0, len(snapshots))
+	for i := range snapshots {
+		entry := map[string]interface{}{
+			"capturedAt": capturedAt[i],
+			"id":         ids[i],
+			"quotas":     map[string]interface{}{},
+		}
+		quotas := map[string]interface{}{}
+		for _, qn := range quotaNames {
+			if qv, ok := series[i][qn]; ok {
+				quotas[qn] = map[string]interface{}{
+					"name":     qv.Name,
+					"value":    qv.Value,
+					"limit":    qv.Limit,
+					"percent":  qv.Percent,
+					"hasValue": qv.HasValue,
+					"hasLimit": qv.HasLimit,
+				}
+			}
+		}
+		entry["quotas"] = quotas
+		logs = append(logs, entry)
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"provider":   "openrouter",
+		"quotaNames": quotaNames,
+		"logs":       logs,
+	})
+}
+
 // Cycles returns reset cycle data (API endpoint)
 func (h *Handler) Cycles(w http.ResponseWriter, r *http.Request) {
 	provider, err := h.getProviderFromRequest(r)
@@ -1873,6 +2378,8 @@ func (h *Handler) Cycles(w http.ResponseWriter, r *http.Request) {
 		h.cyclesAntigravity(w, r)
 	case "minimax":
 		h.cyclesMiniMax(w, r)
+	case "openrouter":
+		h.cyclesOpenRouter(w, r)
 	case "gemini":
 		h.cyclesGemini(w, r)
 	default:
@@ -1993,6 +2500,25 @@ func (h *Handler) cyclesBoth(w http.ResponseWriter, r *http.Request) {
 			response["minimax"] = minimaxCycles
 		}
 	}
+	if h.config.HasProvider("openrouter") {
+		quotaType := "credits"
+		var orCycles []map[string]interface{}
+		if active, err := h.store.QueryActiveOpenRouterCycle(quotaType); err == nil && active != nil {
+			orCycles = append(orCycles, openrouterCycleToMap(active))
+		}
+		if history, err := h.store.QueryOpenRouterCycleHistory(quotaType, 50); err == nil {
+			for _, c := range history {
+				orCycles = append(orCycles, openrouterCycleToMap(c))
+			}
+		}
+		response["openrouter"] = map[string]interface{}{
+			"groupBy":    quotaType,
+			"provider":   "openrouter",
+			"quotaNames": []string{"credits"},
+			"cycles":     orCycles,
+		}
+	}
+
 	if h.config.HasProvider("gemini") {
 		response["gemini"] = []interface{}{}
 	}
@@ -2165,6 +2691,8 @@ func (h *Handler) Summary(w http.ResponseWriter, r *http.Request) {
 		h.summaryAntigravity(w, r)
 	case "minimax":
 		h.summaryMiniMax(w, r)
+	case "openrouter":
+		h.summaryOpenRouter(w, r)
 	case "gemini":
 		h.summaryGemini(w, r)
 	default:
@@ -2196,6 +2724,9 @@ func (h *Handler) summaryBoth(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.config.HasProvider("zai") {
 		response["zai"] = h.buildZaiSummaryMap()
+	}
+	if h.config.HasProvider("openrouter") {
+		response["openrouter"] = h.buildOpenRouterSummaryMap()
 	}
 	if h.config.HasProvider("anthropic") {
 		response["anthropic"] = h.buildAnthropicSummaryMap()
@@ -2778,8 +3309,30 @@ func (h *Handler) sessionsBoth(w http.ResponseWriter, r *http.Request) {
 	if h.config.HasProvider("minimax") {
 		response["minimax"] = buildSessionList("minimax")
 	}
+	if h.config.HasProvider("openrouter") {
+		quotaType := "credits"
+		var orCycles []map[string]interface{}
+		if active, err := h.store.QueryActiveOpenRouterCycle(quotaType); err == nil && active != nil {
+			orCycles = append(orCycles, openrouterCycleToMap(active))
+		}
+		if history, err := h.store.QueryOpenRouterCycleHistory(quotaType, 50); err == nil {
+			for _, c := range history {
+				orCycles = append(orCycles, openrouterCycleToMap(c))
+			}
+		}
+		response["openrouter"] = map[string]interface{}{
+			"groupBy":    quotaType,
+			"provider":   "openrouter",
+			"quotaNames": []string{"credits"},
+			"cycles":     orCycles,
+		}
+	}
+
 	if h.config.HasProvider("gemini") {
 		response["gemini"] = buildSessionList("gemini")
+	}
+	if h.config.HasProvider("openrouter") {
+		response["openrouter"] = buildSessionList("openrouter")
 	}
 
 	respondJSON(w, http.StatusOK, response)
@@ -2918,6 +3471,8 @@ func (h *Handler) Insights(w http.ResponseWriter, r *http.Request) {
 		h.insightsAntigravity(w, r, rangeDur)
 	case "minimax":
 		h.insightsMiniMax(w, r, rangeDur)
+	case "openrouter":
+		h.insightsOpenRouter(w, r, rangeDur)
 	case "gemini":
 		h.insightsGemini(w, r, rangeDur)
 	default:
@@ -2971,6 +3526,9 @@ func (h *Handler) insightsBoth(w http.ResponseWriter, r *http.Request, rangeDur 
 	}
 	if h.config.HasProvider("minimax") && providerTelemetryEnabled(visibility, "minimax") {
 		response["minimax"] = h.buildMiniMaxInsights(hidden, rangeDur)
+	}
+	if h.config.HasProvider("openrouter") && providerTelemetryEnabled(visibility, "openrouter") {
+		response["openrouter"] = h.buildOpenRouterInsights(hidden)
 	}
 	if h.config.HasProvider("gemini") && providerTelemetryEnabled(visibility, "gemini") {
 		response["gemini"] = insightsResponse{Stats: []insightStat{}, Insights: []insightItem{}}
@@ -5065,6 +5623,8 @@ func (h *Handler) CycleOverview(w http.ResponseWriter, r *http.Request) {
 		h.cycleOverviewAntigravity(w, r)
 	case "minimax":
 		h.cycleOverviewMiniMax(w, r)
+	case "openrouter":
+		h.cycleOverviewOpenRouter(w, r)
 	case "gemini":
 		h.cycleOverviewGemini(w, r)
 	default:
@@ -5309,6 +5869,25 @@ func (h *Handler) cycleOverviewBoth(w http.ResponseWriter, r *http.Request) {
 				"quotaNames": quotaNames,
 				"cycles":     cycleOverviewRowsToJSON(rows),
 			}
+		}
+	}
+
+	if h.config.HasProvider("openrouter") {
+		quotaType := "credits"
+		var orCycles []map[string]interface{}
+		if active, err := h.store.QueryActiveOpenRouterCycle(quotaType); err == nil && active != nil {
+			orCycles = append(orCycles, openrouterCycleToMap(active))
+		}
+		if history, err := h.store.QueryOpenRouterCycleHistory(quotaType, 50); err == nil {
+			for _, c := range history {
+				orCycles = append(orCycles, openrouterCycleToMap(c))
+			}
+		}
+		response["openrouter"] = map[string]interface{}{
+			"groupBy":    quotaType,
+			"provider":   "openrouter",
+			"quotaNames": []string{"credits"},
+			"cycles":     orCycles,
 		}
 	}
 
@@ -7826,6 +8405,8 @@ func (h *Handler) LoggingHistory(w http.ResponseWriter, r *http.Request) {
 		h.loggingHistoryAntigravity(w, r)
 	case "minimax":
 		h.loggingHistoryMiniMax(w, r)
+	case "openrouter":
+		h.loggingHistoryOpenRouter(w, r)
 	case "gemini":
 		h.loggingHistoryGemini(w, r)
 	default:

--- a/main.go
+++ b/main.go
@@ -725,6 +725,12 @@ func run() error {
 		logger.Info("MiniMax API client configured", "region", cfg.MiniMaxRegion)
 	}
 
+	var openrouterClient *api.OpenRouterClient
+	if cfg.HasProvider("openrouter") {
+		openrouterClient = api.NewOpenRouterClient(cfg.OpenRouterAPIKey, logger)
+		logger.Info("OpenRouter API client configured")
+	}
+
 	// Gemini provider - env vars or auto-detect from ~/.gemini/oauth_creds.json
 	var geminiClient *api.GeminiClient
 	var geminiCreds *api.GeminiCredentials
@@ -831,6 +837,11 @@ func run() error {
 		minimaxTr = tracker.NewMiniMaxTracker(db, logger)
 	}
 
+	var openrouterTr *tracker.OpenRouterTracker
+	if cfg.HasProvider("openrouter") {
+		openrouterTr = tracker.NewOpenRouterTracker(db, logger)
+	}
+
 	var geminiTr *tracker.GeminiTracker
 	if cfg.HasProvider("gemini") {
 		geminiTr = tracker.NewGeminiTracker(db, logger)
@@ -846,6 +857,12 @@ func run() error {
 	if minimaxClient != nil {
 		minimaxSm := agent.NewSessionManager(db, "minimax", idleTimeout, logger)
 		minimaxAg = agent.NewMiniMaxAgent(minimaxClient, db, minimaxTr, cfg.PollInterval, logger, minimaxSm)
+	}
+
+	var openrouterAg *agent.OpenRouterAgent
+	if openrouterClient != nil {
+		openrouterSm := agent.NewSessionManager(db, "openrouter", idleTimeout, logger)
+		openrouterAg = agent.NewOpenRouterAgent(openrouterClient, db, openrouterTr, cfg.PollInterval, logger, openrouterSm)
 	}
 
 	var geminiAg *agent.GeminiAgent
@@ -887,6 +904,9 @@ func run() error {
 	}
 	if minimaxAg != nil {
 		minimaxAg.SetNotifier(notifier)
+	}
+	if openrouterAg != nil {
+		openrouterAg.SetNotifier(notifier)
 	}
 	if geminiAg != nil {
 		geminiAg.SetNotifier(notifier)
@@ -960,6 +980,9 @@ func run() error {
 	if minimaxAg != nil {
 		minimaxAg.SetPollingCheck(func() bool { return isPollingEnabled("minimax") })
 	}
+	if openrouterAg != nil {
+		openrouterAg.SetPollingCheck(func() bool { return isPollingEnabled("openrouter") })
+	}
 	if geminiAg != nil {
 		geminiAg.SetPollingCheck(func() bool { return isPollingEnabled("gemini") })
 	}
@@ -998,6 +1021,11 @@ func run() error {
 			notifier.Check(notify.QuotaStatus{Provider: "minimax", QuotaKey: modelName, ResetOccurred: true})
 		})
 	}
+	if openrouterTr != nil {
+		openrouterTr.SetOnReset(func(quotaName string) {
+			notifier.Check(notify.QuotaStatus{Provider: "openrouter", QuotaKey: quotaName, ResetOccurred: true})
+		})
+	}
 	if geminiTr != nil {
 		geminiTr.SetOnReset(func(modelID string) {
 			notifier.Check(notify.QuotaStatus{Provider: "gemini", QuotaKey: modelID, ResetOccurred: true})
@@ -1021,6 +1049,9 @@ func run() error {
 	}
 	if minimaxTr != nil {
 		handler.SetMiniMaxTracker(minimaxTr)
+	}
+	if openrouterTr != nil {
+		handler.SetOpenRouterTracker(openrouterTr)
 	}
 	if geminiTr != nil {
 		handler.SetGeminiTracker(geminiTr)
@@ -1047,6 +1078,9 @@ func run() error {
 	if minimaxAg != nil {
 		agentMgr.RegisterFactory("minimax", func() (agent.AgentRunner, error) { return minimaxAg, nil })
 	}
+	if openrouterAg != nil {
+		agentMgr.RegisterFactory("openrouter", func() (agent.AgentRunner, error) { return openrouterAg, nil })
+	}
 	if geminiAg != nil {
 		agentMgr.RegisterFactory("gemini", func() (agent.AgentRunner, error) { return geminiAg, nil })
 	}
@@ -1069,7 +1103,7 @@ func run() error {
 
 	// Start configured agents through the manager.
 	startedAny := false
-	for _, providerKey := range []string{"synthetic", "zai", "anthropic", "copilot", "codex", "antigravity", "minimax", "gemini"} {
+	for _, providerKey := range []string{"synthetic", "zai", "anthropic", "copilot", "codex", "antigravity", "minimax", "openrouter", "gemini"} {
 		if !isPollingEnabled(providerKey) {
 			continue
 		}
@@ -1554,6 +1588,9 @@ func printBanner(cfg *config.Config, version string) {
 	if cfg.HasProvider("minimax") {
 		fmt.Println("║  API:       minimax.io/coding_plan   ║")
 	}
+	if cfg.HasProvider("openrouter") {
+		fmt.Println("║  API:       openrouter.ai/api         ║")
+	}
 	if cfg.HasProvider("gemini") {
 		fmt.Println("║  API:       cloudcode-pa.google.com  ║")
 	}
@@ -1597,6 +1634,9 @@ func printBanner(cfg *config.Config, version string) {
 	}
 	if cfg.HasProvider("minimax") {
 		fmt.Printf("MiniMax API Key:   %s\n", redactAPIKey(cfg.MiniMaxAPIKey))
+	}
+	if cfg.HasProvider("openrouter") {
+		fmt.Printf("OpenRouter Key:    %s\n", redactAPIKey(cfg.OpenRouterAPIKey))
 	}
 	if cfg.HasProvider("gemini") {
 		source := "auto-detect"
@@ -1645,6 +1685,7 @@ func printHelp() {
 	fmt.Println("  CODEX_TOKEN             Codex OAuth token (recommended; required for Codex-only)")
 	fmt.Println("  MINIMAX_API_KEY         MiniMax API key")
 	fmt.Println("  MINIMAX_REGION          MiniMax region: global or cn (default: global)")
+	fmt.Println("  OPENROUTER_API_KEY      OpenRouter API key")
 	fmt.Println("  CODEX_HOME              Optional Codex auth directory (uses CODEX_HOME/auth.json)")
 	fmt.Println("  ONWATCH_POLL_INTERVAL   Polling interval in seconds")
 	fmt.Println("  ONWATCH_PORT            Dashboard HTTP port")


### PR DESCRIPTION
## Summary

Adds **OpenRouter** as a new provider for tracking API credit usage, spending rates, and rate limits.

### What it does

Polls `GET /api/v1/auth/key` to track:
- **Total usage** (USD cumulative)
- **Daily/weekly/monthly** usage breakdowns
- **Credit limit** and remaining balance (when a spending limit is configured)
- **Rate limit** info (requests per interval)
- **Free tier** detection

### Why

OpenRouter is widely used by developers running multi-model setups (Claude, GPT, Llama, Mistral, etc.) through a single API. There's currently no way to monitor OpenRouter quota/spending in onWatch — this fills that gap.

### Implementation

Follows the existing provider pattern (Z.ai / MiniMax):

| File | Purpose |
|------|---------|
| `internal/api/openrouter_client.go` | HTTP client with Bearer auth |
| `internal/api/openrouter_types.go` | Response structs, snapshot type |
| `internal/store/openrouter_store.go` | SQLite storage + cycle tracking |
| `internal/tracker/openrouter_tracker.go` | Delta tracking, rate projections |
| `internal/agent/openrouter_agent.go` | Polling agent |

Integration points modified:
- `internal/config/config.go` — `OPENROUTER_API_KEY` env var + `HasProvider()`
- `internal/store/store.go` — Schema tables + indexes
- `internal/web/handlers.go` — Dashboard endpoints (current, history, cycles, insights, sessions)
- `main.go` — Client/tracker/agent wiring + banner display
- `.env.example` — New env var entry

### Testing

- `go build ./...` — clean
- `go vet ./...` — clean  
- Tested locally with a real OpenRouter API key — polling works, snapshots stored, cycle tracking functional

### Dashboard

The OpenRouter tab shows:
- Credits usage card (usage vs limit when configured, or total usage)
- Daily/weekly/monthly usage breakdowns
- Usage rate projections
- Historical chart data
- Session tracking
- Cycle overview

### Configuration

```bash
OPENROUTER_API_KEY=sk-or-v1-your-key-here
```

No auto-detection — requires explicit API key in `.env` or environment.