### PR TITLE
fix: add explicit expiry to login session cookie

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -4897,6 +4897,7 @@ func (h *Handler) loginPost(w http.ResponseWriter, r *http.Request) {
 		Value:    token,
 		Path:     "/",
 		MaxAge:   sessionMaxAge,
+		Expires:  time.Now().Add(time.Duration(sessionMaxAge) * time.Second),
 		HttpOnly: true,
 		Secure:   h.config.SecureCookies || (h.config.Host != "" && h.config.Host != "0.0.0.0" && h.config.Host != "127.0.0.1"),
 		SameSite: http.SameSiteStrictMode,

--- a/internal/web/handlers_extra_test.go
+++ b/internal/web/handlers_extra_test.go
@@ -6800,15 +6800,27 @@ func TestHandler_LoginPost_SuccessWithRateLimiter(t *testing.T) {
 
 	// Cookie should be set
 	cookies := rr.Result().Cookies()
-	found := false
+	var sessionCookie *http.Cookie
 	for _, c := range cookies {
 		if c.Name == "onwatch_session" {
-			found = true
+			sessionCookie = c
 			break
 		}
 	}
-	if !found {
+	if sessionCookie == nil {
 		t.Error("expected session cookie to be set")
+		return
+	}
+	if sessionCookie.MaxAge != sessionMaxAge {
+		t.Errorf("expected MaxAge %d, got %d", sessionMaxAge, sessionCookie.MaxAge)
+	}
+	if sessionCookie.Expires.IsZero() {
+		t.Error("expected Expires to be set for persistent session cookie")
+	}
+	expectedMin := time.Now().Add(time.Duration(sessionMaxAge-5) * time.Second)
+	expectedMax := time.Now().Add(time.Duration(sessionMaxAge+5) * time.Second)
+	if sessionCookie.Expires.Before(expectedMin) || sessionCookie.Expires.After(expectedMax) {
+		t.Errorf("expected Expires within [%v, %v], got %v", expectedMin, expectedMax, sessionCookie.Expires)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add an explicit `Expires` timestamp alongside the existing `MaxAge` when issuing the login session cookie
- keep the change scoped to the login cookie path and extend the existing handler test to assert persistent-cookie attributes

## Why
Safari on iPhone appears to stop sending the session cookie over time even though the server-side auth token remains valid. Setting both `MaxAge` and `Expires` keeps the cookie persistence behavior standards-aligned with a minimal blast radius.

## Testing
- go test ./internal/web -run 'TestHandler_LoginPost_SuccessWithRateLimiter'
- go test -tags=integration . -run 'TestIntegration_Auth_LoginSessionDashboard'