### PR TITLE
feat: add support for Opencode GO

### DIFF
--- a/internal/agent/opencode_agent.go
+++ b/internal/agent/opencode_agent.go
@@ -1,0 +1,219 @@
+package agent
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+	"github.com/onllm-dev/onwatch/v2/internal/notify"
+	"github.com/onllm-dev/onwatch/v2/internal/store"
+	"github.com/onllm-dev/onwatch/v2/internal/tracker"
+)
+
+const maxOpenCodeAuthFailures = 3
+
+// OpenCodeCookieRefreshFunc is called before each poll to get a fresh OpenCode cookie.
+type OpenCodeCookieRefreshFunc func() string
+
+// OpenCodeAgent manages the background polling loop for OpenCode quota tracking.
+type OpenCodeAgent struct {
+	client       *api.OpenCodeClient
+	store        *store.Store
+	tracker      *tracker.OpenCodeTracker
+	interval     time.Duration
+	logger       *slog.Logger
+	sm           *SessionManager
+	notifier     *notify.NotificationEngine
+	pollingCheck func() bool
+	cookieRefresh OpenCodeCookieRefreshFunc
+	lastCookie   string
+
+	// Auth failure rate limiting
+	authFailCount   int
+	authPaused      bool
+	lastFailedCookie string
+}
+
+// NewOpenCodeAgent creates a new OpenCodeAgent with the given dependencies.
+func NewOpenCodeAgent(client *api.OpenCodeClient, st *store.Store, tracker *tracker.OpenCodeTracker, interval time.Duration, logger *slog.Logger, sm *SessionManager) *OpenCodeAgent {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OpenCodeAgent{
+		client:   client,
+		store:    st,
+		tracker:  tracker,
+		interval: interval,
+		logger:   logger,
+		sm:       sm,
+	}
+}
+
+// SetPollingCheck sets a function called before each poll.
+func (a *OpenCodeAgent) SetPollingCheck(fn func() bool) {
+	a.pollingCheck = fn
+}
+
+// SetNotifier sets notification engine for sending alerts.
+func (a *OpenCodeAgent) SetNotifier(n *notify.NotificationEngine) {
+	a.notifier = n
+}
+
+// SetCookieRefresh sets a function called before each poll to refresh OpenCode cookie.
+func (a *OpenCodeAgent) SetCookieRefresh(fn OpenCodeCookieRefreshFunc) {
+	a.cookieRefresh = fn
+}
+
+// Run starts the agent polling loop.
+func (a *OpenCodeAgent) Run(ctx context.Context) error {
+	a.logger.Info("OpenCode agent started", "interval", a.interval)
+
+	defer func() {
+		if a.sm != nil {
+			a.sm.Close()
+		}
+		a.logger.Info("OpenCode agent stopped")
+	}()
+
+	a.poll(ctx)
+
+	ticker := time.NewTicker(a.interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			a.poll(ctx)
+		case <-ctx.Done():
+			return nil
+		}
+	}
+}
+
+func (a *OpenCodeAgent) poll(ctx context.Context) {
+	if a.pollingCheck != nil && !a.pollingCheck() {
+		return
+	}
+
+	// Refresh cookie before each poll (picks up rotated credentials)
+	if a.cookieRefresh != nil {
+		newCookie := a.cookieRefresh()
+		if newCookie != "" && newCookie != a.lastCookie {
+			a.client.SetCookieHeader(newCookie)
+			a.lastCookie = newCookie
+			a.logger.Info("OpenCode cookie refreshed")
+
+			// If we were paused due to auth failures and cookie changed, resume.
+			if a.authPaused && newCookie != a.lastFailedCookie {
+				a.authPaused = false
+				a.authFailCount = 0
+				a.lastFailedCookie = ""
+				a.logger.Info("OpenCode auth failure pause lifted - new cookie detected")
+			}
+		}
+	}
+
+	// If auth is paused, skip polling until cookie changes.
+	if a.authPaused {
+		return
+	}
+
+	snapshot, err := a.client.FetchQuotas(ctx, "")
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+
+		// On auth error, force cookie re-read and retry once.
+		if errors.Is(err, api.ErrOpenCodeUnauthorized) && a.cookieRefresh != nil {
+			a.logger.Warn("OpenCode auth error, forcing cookie re-read", "error", err)
+			a.lastCookie = "" // force re-read even if unchanged
+			if retryCookie := a.cookieRefresh(); retryCookie != "" {
+				a.client.SetCookieHeader(retryCookie)
+				a.lastCookie = retryCookie
+				a.logger.Info("Retrying OpenCode poll with refreshed cookie")
+				snapshot, err = a.client.FetchQuotas(ctx, "")
+				if err != nil {
+					if ctx.Err() != nil {
+						return
+					}
+					if errors.Is(err, api.ErrOpenCodeUnauthorized) {
+						a.authFailCount++
+						a.lastFailedCookie = retryCookie
+						a.logger.Error("OpenCode auth retry failed",
+							"error", err,
+							"failure_count", a.authFailCount,
+							"max_failures", maxOpenCodeAuthFailures)
+
+						if a.authFailCount >= maxOpenCodeAuthFailures {
+							a.authPaused = true
+							a.logger.Error("OpenCode polling PAUSED due to repeated auth failures",
+								"failure_count", a.authFailCount,
+								"action", "Re-authenticate OpenCode to resume polling")
+						}
+					} else {
+						a.logger.Error("OpenCode retry failed with non-auth error", "error", err)
+					}
+					return
+				}
+				// Retry succeeded, reset auth failure count.
+				a.authFailCount = 0
+			} else {
+				a.logger.Error("No OpenCode cookie available after re-read")
+				return
+			}
+		} else {
+			a.logger.Error("Failed to fetch OpenCode quotas", "error", err)
+			return
+		}
+	} else {
+		// Success, reset auth failure count.
+		a.authFailCount = 0
+	}
+
+	if _, err := a.store.InsertOpenCodeSnapshot(snapshot); err != nil {
+		a.logger.Error("Failed to insert OpenCode snapshot", "error", err)
+		return
+	}
+
+	if a.tracker != nil {
+		if err := a.tracker.Process(snapshot); err != nil {
+			a.logger.Error("OpenCode tracker processing failed", "error", err)
+		}
+	}
+
+	if a.notifier != nil {
+		quotas := []api.OpenCodeQuota{snapshot.RollingUsage, snapshot.WeeklyUsage}
+		if snapshot.HasMonthlyUsage {
+			quotas = append(quotas, snapshot.MonthlyUsage)
+		}
+		for _, q := range quotas {
+			a.notifier.Check(notify.QuotaStatus{
+				Provider:    "opencode",
+				QuotaKey:    q.Name,
+				Utilization: q.Utilization,
+				Limit:       100, // OpenCode uses percentages
+			})
+		}
+	}
+
+	if a.sm != nil {
+		values := []float64{
+			snapshot.RollingUsage.Utilization,
+			snapshot.WeeklyUsage.Utilization,
+		}
+		if snapshot.HasMonthlyUsage {
+			values = append(values, snapshot.MonthlyUsage.Utilization)
+		}
+		a.sm.ReportPoll(values)
+	}
+
+	a.logger.Info("OpenCode poll complete",
+		"workspace_id", snapshot.WorkspaceID,
+		"rolling_percent", snapshot.RollingUsage.Utilization,
+		"weekly_percent", snapshot.WeeklyUsage.Utilization,
+		"has_monthly", snapshot.HasMonthlyUsage,
+	)
+}

--- a/internal/api/opencode_client.go
+++ b/internal/api/opencode_client.go
@@ -1,0 +1,404 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrOpenCodeUnauthorized    = errors.New("opencode: unauthorized - invalid or expired cookie")
+	ErrOpenCodeNetworkError    = errors.New("opencode: network error")
+	ErrOpenCodeInvalidResponse = errors.New("opencode: invalid response")
+	ErrOpenCodeParseFailed     = errors.New("opencode: parse failed")
+)
+
+const (
+	OpenCodeBaseURL      = "https://opencode.ai"
+	OpenCodeServerURL    = "https://opencode.ai/_server"
+	OpenCodeWorkspacesID = "def39973159c7f0483d8793a822b8dbb10d067e12c65455fcb4608459ba0234f"
+	OpenCodeUserAgent    = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/143.0.0.0 Safari/537.36"
+)
+
+type OpenCodeClient struct {
+	httpClient   *http.Client
+	cookieHeader string
+	cookieMu     sync.RWMutex
+	baseURL      string
+	serverURL    string
+	logger       *slog.Logger
+}
+
+type OpenCodeOption func(*OpenCodeClient)
+
+func WithOpenCodeBaseURL(url string) OpenCodeOption {
+	return func(c *OpenCodeClient) {
+		c.baseURL = url
+	}
+}
+
+func WithOpenCodeTimeout(timeout time.Duration) OpenCodeOption {
+	return func(c *OpenCodeClient) {
+		c.httpClient.Timeout = timeout
+	}
+}
+
+// NormalizeOpenCodeCookie converts a raw auth cookie value into a valid
+// Cookie header value expected by OpenCode requests.
+func NormalizeOpenCodeCookie(raw string) string {
+	cookie := strings.TrimSpace(raw)
+	if cookie == "" {
+		return ""
+	}
+
+	lower := strings.ToLower(cookie)
+	if strings.HasPrefix(lower, "auth=") || strings.Contains(lower, ";auth=") || strings.Contains(lower, "; auth=") {
+		return cookie
+	}
+	return "auth=" + cookie
+}
+
+func NewOpenCodeClient(cookieHeader string, logger *slog.Logger, opts ...OpenCodeOption) *OpenCodeClient {
+	client := &OpenCodeClient{
+		httpClient: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:          1,
+				MaxIdleConnsPerHost:   1,
+				ResponseHeaderTimeout: 30 * time.Second,
+				IdleConnTimeout:       30 * time.Second,
+				TLSHandshakeTimeout:   10 * time.Second,
+				ForceAttemptHTTP2:     true,
+			},
+		},
+		cookieHeader: NormalizeOpenCodeCookie(cookieHeader),
+		baseURL:      OpenCodeBaseURL,
+		serverURL:    OpenCodeServerURL,
+		logger:       logger,
+	}
+
+	for _, opt := range opts {
+		opt(client)
+	}
+
+	return client
+}
+
+// DetectOpenCodeCookie attempts to auto-detect the OpenCode cookie.
+// Returns empty string if not found.
+// For now, this checks environment variable. Future versions may detect from browser cookies.
+func DetectOpenCodeCookie(logger *slog.Logger) string {
+	// Check environment variable first
+	if cookie := os.Getenv("OPENCODE_COOKIE"); cookie != "" {
+		return NormalizeOpenCodeCookie(cookie)
+	}
+
+	// TODO: Add browser cookie detection for future versions
+	// This would involve reading browser cookie stores on different platforms
+
+	return ""
+}
+
+func (c *OpenCodeClient) SetCookieHeader(cookieHeader string) {
+	c.cookieMu.Lock()
+	defer c.cookieMu.Unlock()
+	c.cookieHeader = NormalizeOpenCodeCookie(cookieHeader)
+}
+
+func (c *OpenCodeClient) getCookieHeader() string {
+	c.cookieMu.RLock()
+	defer c.cookieMu.RUnlock()
+	return c.cookieHeader
+}
+
+func (c *OpenCodeClient) GetCookieHeader() string {
+	return c.getCookieHeader()
+}
+
+func (c *OpenCodeClient) FetchQuotas(ctx context.Context, workspaceIDOverride string) (*OpenCodeSnapshot, error) {
+	cookieHeader := c.getCookieHeader()
+	if cookieHeader == "" {
+		return nil, ErrOpenCodeUnauthorized
+	}
+
+	workspaceID := workspaceIDOverride
+	if workspaceID == "" {
+		var err error
+		workspaceID, err = c.fetchWorkspaceID(ctx, cookieHeader)
+		if err != nil {
+			return nil, fmt.Errorf("opencode: fetch workspace ID: %w", err)
+		}
+	}
+
+	html, err := c.fetchUsagePage(ctx, workspaceID, cookieHeader)
+	if err != nil {
+		return nil, fmt.Errorf("opencode: fetch usage page: %w", err)
+	}
+
+	usage, err := ParseOpenCodeUsageFromHTML(html, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("opencode: parse usage: %w", err)
+	}
+
+	snapshot := ToOpenCodeSnapshot(workspaceID, usage)
+	c.logger.Debug("opencode: quotas fetched",
+		"workspace_id", workspaceID,
+		"rolling_percent", usage.RollingUsagePercent,
+		"weekly_percent", usage.WeeklyUsagePercent,
+		"monthly_percent", usage.MonthlyUsagePercent,
+		"has_monthly", usage.HasMonthlyUsage,
+	)
+
+	return snapshot, nil
+}
+
+func (c *OpenCodeClient) fetchWorkspaceID(ctx context.Context, cookieHeader string) (string, error) {
+	// Try GET first
+	text, err := c.fetchServerText(ctx, cookieHeader, OpenCodeWorkspacesID, "GET", "")
+	if err != nil {
+		return "", err
+	}
+
+	if c.looksSignedOut(text) {
+		return "", ErrOpenCodeUnauthorized
+	}
+
+	ids := c.parseWorkspaceIDs(text)
+	if len(ids) == 0 {
+		// Try POST as fallback
+		c.logger.Debug("opencode: workspace IDs missing after GET, retrying with POST")
+		text, err = c.fetchServerText(ctx, cookieHeader, OpenCodeWorkspacesID, "POST", "[]")
+		if err != nil {
+			return "", err
+		}
+		if c.looksSignedOut(text) {
+			return "", ErrOpenCodeUnauthorized
+		}
+		ids = c.parseWorkspaceIDs(text)
+		if len(ids) == 0 {
+			return "", ErrOpenCodeParseFailed
+		}
+	}
+
+	return ids[0], nil
+}
+
+func (c *OpenCodeClient) fetchUsagePage(ctx context.Context, workspaceID, cookieHeader string) (string, error) {
+	usageURL := fmt.Sprintf("%s/workspace/%s/go", c.baseURL, workspaceID)
+
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, http.MethodGet, usageURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("opencode: create usage request: %w", err)
+	}
+
+	req.Header.Set("Cookie", cookieHeader)
+	req.Header.Set("User-Agent", OpenCodeUserAgent)
+	req.Header.Set("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		return "", fmt.Errorf("%w: %v", ErrOpenCodeNetworkError, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return "", fmt.Errorf("%w: reading body: %v", ErrOpenCodeInvalidResponse, err)
+	}
+
+	switch {
+	case resp.StatusCode == http.StatusOK:
+		// Continue
+	case resp.StatusCode == http.StatusUnauthorized:
+		return "", ErrOpenCodeUnauthorized
+	case resp.StatusCode == http.StatusForbidden:
+		return "", ErrOpenCodeUnauthorized
+	case resp.StatusCode >= 500:
+		return "", fmt.Errorf("opencode: server error %d", resp.StatusCode)
+	default:
+		return "", fmt.Errorf("opencode: unexpected status %d", resp.StatusCode)
+	}
+
+	html := string(body)
+	if c.looksSignedOut(html) {
+		return "", ErrOpenCodeUnauthorized
+	}
+
+	// Validate that usage fields are present
+	if !c.hasUsageFields(html) {
+		c.logger.Error("opencode: usage page payload missing usage fields")
+		return "", ErrOpenCodeParseFailed
+	}
+
+	return html, nil
+}
+
+func (c *OpenCodeClient) fetchServerText(ctx context.Context, cookieHeader, serverID, method string, args string) (string, error) {
+	reqURL := c.serverURL
+	if method == "GET" {
+		baseURL, err := url.Parse(c.serverURL)
+		if err != nil {
+			return "", err
+		}
+		query := baseURL.Query()
+		query.Set("id", serverID)
+		if args != "" {
+			query.Set("args", args)
+		}
+		baseURL.RawQuery = query.Encode()
+		reqURL = baseURL.String()
+	}
+
+	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(reqCtx, method, reqURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("opencode: create server request: %w", err)
+	}
+
+	req.Header.Set("Cookie", cookieHeader)
+	req.Header.Set("X-Server-Id", serverID)
+	req.Header.Set("X-Server-Instance", "server-fn:"+generateUUID())
+	req.Header.Set("User-Agent", OpenCodeUserAgent)
+	req.Header.Set("Origin", c.baseURL)
+	req.Header.Set("Referer", c.baseURL)
+	req.Header.Set("Accept", "text/javascript, application/json;q=0.9, */*;q=0.8")
+
+	if method != "GET" && args != "" {
+		req.Header.Set("Content-Type", "application/json")
+		req.Body = io.NopCloser(strings.NewReader(args))
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctx.Err() != nil {
+			return "", ctx.Err()
+		}
+		return "", fmt.Errorf("%w: %v", ErrOpenCodeNetworkError, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<16))
+	if err != nil {
+		return "", fmt.Errorf("%w: reading body: %v", ErrOpenCodeInvalidResponse, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		bodyText := string(body)
+		if c.looksSignedOut(bodyText) {
+			return "", ErrOpenCodeUnauthorized
+		}
+		if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+			return "", ErrOpenCodeUnauthorized
+		}
+		return "", fmt.Errorf("opencode: server returned %d", resp.StatusCode)
+	}
+
+	return string(body), nil
+}
+
+func (c *OpenCodeClient) parseWorkspaceIDs(text string) []string {
+	pattern := `id\s*:\s*"(wrk_[^"]+)"`
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+
+	matches := re.FindAllStringSubmatch(text, -1)
+	var ids []string
+	for _, match := range matches {
+		if len(match) > 1 {
+			ids = append(ids, match[1])
+		}
+	}
+	return ids
+}
+
+func (c *OpenCodeClient) looksSignedOut(text string) bool {
+	lower := strings.ToLower(text)
+	return strings.Contains(lower, "login") ||
+		strings.Contains(lower, "sign in") ||
+		strings.Contains(lower, "auth/authorize") ||
+		strings.Contains(lower, "not associated with an account") ||
+		strings.Contains(lower, "actor of type \"public\"")
+}
+
+func (c *OpenCodeClient) hasUsageFields(html string) bool {
+	// Check if either JSON parsing or regex extraction would work
+	rollingPattern := `rollingUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)`
+	re, err := regexp.Compile(rollingPattern)
+	if err == nil && re.MatchString(html) {
+		return true
+	}
+	return false
+}
+
+func generateUUID() string {
+	// Simple UUID v4 generator
+	return fmt.Sprintf("%x-%x-%x-%x-%x",
+		randUint32(), randUint16(), randUint16(),
+		randUint16(), randUint48())
+}
+
+func randUint32() uint32 {
+	return uint32(time.Now().UnixNano())
+}
+
+func randUint16() uint16 {
+	return uint16(time.Now().UnixNano())
+}
+
+func randUint48() uint64 {
+	return uint64(time.Now().UnixNano())
+}
+
+func NormalizeWorkspaceID(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	trimmed := strings.TrimSpace(raw)
+
+	// Already in correct format
+	if strings.HasPrefix(trimmed, "wrk_") && len(trimmed) > 4 {
+		return trimmed
+	}
+
+	// Extract from URL
+	if u, err := url.Parse(trimmed); err == nil {
+		parts := strings.Split(u.Path, "/")
+		for i, part := range parts {
+			if part == "workspace" && i+1 < len(parts) {
+				candidate := parts[i+1]
+				if strings.HasPrefix(candidate, "wrk_") && len(candidate) > 4 {
+					return candidate
+				}
+			}
+		}
+	}
+
+	// Extract using regex
+	re, err := regexp.Compile(`wrk_[A-Za-z0-9]+`)
+	if err == nil {
+		if match := re.FindString(trimmed); match != "" {
+			return match
+		}
+	}
+
+	return ""
+}

--- a/internal/api/opencode_client_test.go
+++ b/internal/api/opencode_client_test.go
@@ -1,0 +1,44 @@
+package api
+
+import "testing"
+
+func TestNormalizeOpenCodeCookie(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty", in: "", want: ""},
+		{name: "value_only", in: "abc123", want: "auth=abc123"},
+		{name: "trimmed_value_only", in: "  abc123  ", want: "auth=abc123"},
+		{name: "already_auth_cookie", in: "auth=abc123", want: "auth=abc123"},
+		{name: "multiple_cookie_header", in: "session=foo; auth=abc123; theme=dark", want: "session=foo; auth=abc123; theme=dark"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := NormalizeOpenCodeCookie(tc.in)
+			if got != tc.want {
+				t.Fatalf("NormalizeOpenCodeCookie(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenCodeClient_CookieNormalization(t *testing.T) {
+	t.Parallel()
+
+	client := NewOpenCodeClient("raw_cookie_value", nil)
+	if got, want := client.GetCookieHeader(), "auth=raw_cookie_value"; got != want {
+		t.Fatalf("NewOpenCodeClient cookie = %q, want %q", got, want)
+	}
+
+	client.SetCookieHeader("another_cookie_value")
+	if got, want := client.GetCookieHeader(), "auth=another_cookie_value"; got != want {
+		t.Fatalf("SetCookieHeader cookie = %q, want %q", got, want)
+	}
+}

--- a/internal/api/opencode_types.go
+++ b/internal/api/opencode_types.go
@@ -1,0 +1,174 @@
+package api
+
+import (
+	"encoding/json"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// OpenCodeQuota represents a single quota metric for OpenCode
+type OpenCodeQuota struct {
+	Name        string
+	Used        float64
+	Limit       float64
+	Utilization float64
+	ResetsAt    *time.Time
+	ResetInSec  int
+}
+
+// OpenCodeSnapshot represents the complete quota snapshot for OpenCode
+type OpenCodeSnapshot struct {
+	ID              int64
+	CapturedAt      time.Time
+	WorkspaceID     string
+	RollingUsage    OpenCodeQuota
+	WeeklyUsage     OpenCodeQuota
+	MonthlyUsage    OpenCodeQuota
+	HasMonthlyUsage bool
+	RawJSON         string
+}
+
+// OpenCodeUsageSnapshot is the parsed usage data from OpenCode
+type OpenCodeUsageSnapshot struct {
+	HasMonthlyUsage     bool
+	RollingUsagePercent float64
+	WeeklyUsagePercent  float64
+	MonthlyUsagePercent float64
+	RollingResetInSec   int
+	WeeklyResetInSec    int
+	MonthlyResetInSec   int
+	UpdatedAt           time.Time
+}
+
+// ParseOpenCodeUsageFromHTML extracts usage data from HTML page
+func ParseOpenCodeUsageFromHTML(html string, now time.Time) (*OpenCodeUsageSnapshot, error) {
+	snapshot := &OpenCodeUsageSnapshot{
+		UpdatedAt: now,
+	}
+
+	// Extract rolling usage percent
+	if rollingPercent := extractDoubleFromHTML(html, `rollingUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)`); rollingPercent != nil {
+		snapshot.RollingUsagePercent = normalizeOpenCodeUtilizationFraction(*rollingPercent)
+	}
+	if rollingReset := extractIntFromHTML(html, `rollingUsage[^}]*?resetInSec\s*:\s*([0-9]+)`); rollingReset != nil {
+		snapshot.RollingResetInSec = *rollingReset
+	}
+
+	// Extract weekly usage percent
+	if weeklyPercent := extractDoubleFromHTML(html, `weeklyUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)`); weeklyPercent != nil {
+		snapshot.WeeklyUsagePercent = normalizeOpenCodeUtilizationFraction(*weeklyPercent)
+	}
+	if weeklyReset := extractIntFromHTML(html, `weeklyUsage[^}]*?resetInSec\s*:\s*([0-9]+)`); weeklyReset != nil {
+		snapshot.WeeklyResetInSec = *weeklyReset
+	}
+
+	// Extract monthly usage (optional)
+	if monthlyPercent := extractDoubleFromHTML(html, `monthlyUsage[^}]*?usagePercent\s*:\s*([0-9]+(?:\.[0-9]+)?)`); monthlyPercent != nil {
+		snapshot.MonthlyUsagePercent = normalizeOpenCodeUtilizationFraction(*monthlyPercent)
+		snapshot.HasMonthlyUsage = true
+	}
+	if monthlyReset := extractIntFromHTML(html, `monthlyUsage[^}]*?resetInSec\s*:\s*([0-9]+)`); monthlyReset != nil {
+		snapshot.MonthlyResetInSec = *monthlyReset
+		snapshot.HasMonthlyUsage = true
+	}
+
+	return snapshot, nil
+}
+
+func normalizeOpenCodeUtilizationFraction(value float64) float64 {
+	if value < 0 {
+		return 0
+	}
+	if value >= 1 {
+		if value > 100 {
+			return 1
+		}
+		return value / 100
+	}
+	return value
+}
+
+func extractDoubleFromHTML(html, pattern string) *float64 {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	matches := re.FindStringSubmatch(html)
+	if len(matches) < 2 {
+		return nil
+	}
+	val, err := strconv.ParseFloat(matches[1], 64)
+	if err != nil {
+		return nil
+	}
+	return &val
+}
+
+func extractIntFromHTML(html, pattern string) *int {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	matches := re.FindStringSubmatch(html)
+	if len(matches) < 2 {
+		return nil
+	}
+	val, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil
+	}
+	return &val
+}
+
+// ToOpenCodeSnapshot converts usage data to a snapshot
+func ToOpenCodeSnapshot(workspaceID string, usage *OpenCodeUsageSnapshot) *OpenCodeSnapshot {
+	now := time.Now().UTC()
+
+	snapshot := &OpenCodeSnapshot{
+		CapturedAt:      now,
+		WorkspaceID:     workspaceID,
+		HasMonthlyUsage: usage.HasMonthlyUsage,
+	}
+
+	// Rolling quota
+	snapshot.RollingUsage = OpenCodeQuota{
+		Name:        "rolling",
+		Utilization: usage.RollingUsagePercent,
+		ResetInSec:  usage.RollingResetInSec,
+	}
+	if usage.RollingResetInSec > 0 {
+		resetAt := now.Add(time.Duration(usage.RollingResetInSec) * time.Second)
+		snapshot.RollingUsage.ResetsAt = &resetAt
+	}
+
+	// Weekly quota
+	snapshot.WeeklyUsage = OpenCodeQuota{
+		Name:        "weekly",
+		Utilization: usage.WeeklyUsagePercent,
+		ResetInSec:  usage.WeeklyResetInSec,
+	}
+	if usage.WeeklyResetInSec > 0 {
+		resetAt := now.Add(time.Duration(usage.WeeklyResetInSec) * time.Second)
+		snapshot.WeeklyUsage.ResetsAt = &resetAt
+	}
+
+	// Monthly quota (optional)
+	if usage.HasMonthlyUsage {
+		snapshot.MonthlyUsage = OpenCodeQuota{
+			Name:        "monthly",
+			Utilization: usage.MonthlyUsagePercent,
+			ResetInSec:  usage.MonthlyResetInSec,
+		}
+		if usage.MonthlyResetInSec > 0 {
+			resetAt := now.Add(time.Duration(usage.MonthlyResetInSec) * time.Second)
+			snapshot.MonthlyUsage.ResetsAt = &resetAt
+		}
+	}
+
+	if raw, err := json.Marshal(usage); err == nil {
+		snapshot.RawJSON = string(raw)
+	}
+
+	return snapshot
+}

--- a/internal/api/opencode_types_test.go
+++ b/internal/api/opencode_types_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"math"
+	"testing"
+	"time"
+)
+
+func TestParseOpenCodeUsageFromHTML_NormalizesPercentValues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	html := `rollingUsage:{usagePercent:18,resetInSec:3600},weeklyUsage:{usagePercent:82,resetInSec:7200},monthlyUsage:{usagePercent:5,resetInSec:10800}`
+
+	usage, err := ParseOpenCodeUsageFromHTML(html, now)
+	if err != nil {
+		t.Fatalf("ParseOpenCodeUsageFromHTML returned error: %v", err)
+	}
+
+	if !almostEqual(usage.RollingUsagePercent, 0.18) {
+		t.Fatalf("expected rolling usage 0.18, got %f", usage.RollingUsagePercent)
+	}
+	if !almostEqual(usage.WeeklyUsagePercent, 0.82) {
+		t.Fatalf("expected weekly usage 0.82, got %f", usage.WeeklyUsagePercent)
+	}
+	if !almostEqual(usage.MonthlyUsagePercent, 0.05) {
+		t.Fatalf("expected monthly usage 0.05, got %f", usage.MonthlyUsagePercent)
+	}
+}
+
+func TestParseOpenCodeUsageFromHTML_KeepsFractionValues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	html := `rollingUsage:{usagePercent:0.18,resetInSec:3600},weeklyUsage:{usagePercent:0.82,resetInSec:7200}`
+
+	usage, err := ParseOpenCodeUsageFromHTML(html, now)
+	if err != nil {
+		t.Fatalf("ParseOpenCodeUsageFromHTML returned error: %v", err)
+	}
+
+	if !almostEqual(usage.RollingUsagePercent, 0.18) {
+		t.Fatalf("expected rolling usage 0.18, got %f", usage.RollingUsagePercent)
+	}
+	if !almostEqual(usage.WeeklyUsagePercent, 0.82) {
+		t.Fatalf("expected weekly usage 0.82, got %f", usage.WeeklyUsagePercent)
+	}
+}
+
+func TestParseOpenCodeUsageFromHTML_HandlesOnePercentValues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now().UTC()
+	html := `rollingUsage:{usagePercent:1,resetInSec:3600},weeklyUsage:{usagePercent:1,resetInSec:7200}`
+
+	usage, err := ParseOpenCodeUsageFromHTML(html, now)
+	if err != nil {
+		t.Fatalf("ParseOpenCodeUsageFromHTML returned error: %v", err)
+	}
+
+	if !almostEqual(usage.RollingUsagePercent, 0.01) {
+		t.Fatalf("expected rolling usage 0.01, got %f", usage.RollingUsagePercent)
+	}
+	if !almostEqual(usage.WeeklyUsagePercent, 0.01) {
+		t.Fatalf("expected weekly usage 0.01, got %f", usage.WeeklyUsagePercent)
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -65,6 +65,10 @@ type Config struct {
 	CursorToken     string // CURSOR_TOKEN or auto-detected
 	CursorAutoToken bool   // true if token was auto-detected
 
+	// OpenCode provider configuration (cookie-based authentication)
+	OpenCodeCookie     string // OPENCODE_COOKIE or auto-detected
+	OpenCodeAutoCookie bool   // true if cookie was auto-detected
+
 	// Custom API Integrations telemetry ingestion
 	APIIntegrationsEnabled   bool          // ONWATCH_API_INTEGRATIONS_ENABLED (default: true)
 	APIIntegrationsDir       string        // ONWATCH_API_INTEGRATIONS_DIR (default: ~/.onwatch/api-integrations or /data/api-integrations)
@@ -310,6 +314,7 @@ func loadFromEnvAndFlags(flags *flagValues) (*Config, error) {
 
 	// Cursor provider (auto-detected from Cursor Desktop SQLite or keychain)
 	cfg.CursorToken = strings.TrimSpace(os.Getenv("CURSOR_TOKEN"))
+	cfg.OpenCodeCookie = strings.TrimSpace(os.Getenv("OPENCODE_COOKIE"))
 
 	// Custom API Integrations telemetry ingestion
 	cfg.APIIntegrationsDir = strings.TrimSpace(os.Getenv("ONWATCH_API_INTEGRATIONS_DIR"))
@@ -519,6 +524,9 @@ func (c *Config) AvailableProviders() []string {
 	if c.CursorToken != "" {
 		providers = append(providers, "cursor")
 	}
+	if c.OpenCodeCookie != "" {
+		providers = append(providers, "opencode")
+	}
 	return providers
 }
 
@@ -545,6 +553,8 @@ func (c *Config) HasProvider(name string) bool {
 		return c.GeminiEnabled
 	case "cursor":
 		return c.CursorToken != ""
+	case "opencode":
+		return c.OpenCodeCookie != ""
 	}
 	return false
 }
@@ -580,6 +590,9 @@ func (c *Config) HasMultipleProviders() bool {
 		count++
 	}
 	if c.CursorToken != "" {
+		count++
+	}
+	if c.OpenCodeCookie != "" {
 		count++
 	}
 	return count > 1
@@ -630,6 +643,12 @@ func (c *Config) String() string {
 	fmt.Fprintf(&sb, "  CursorToken: %s,\n", cursorDisplay)
 	if c.CursorAutoToken {
 		fmt.Fprintf(&sb, "  CursorAutoToken: true,\n")
+	}
+
+	opencodeDisplay := redactAPIKey(c.OpenCodeCookie, "")
+	fmt.Fprintf(&sb, "  OpenCodeCookie: %s,\n", opencodeDisplay)
+	if c.OpenCodeAutoCookie {
+		fmt.Fprintf(&sb, "  OpenCodeAutoCookie: true,\n")
 	}
 
 	fmt.Fprintf(&sb, "  PollInterval: %v,\n", c.PollInterval)

--- a/internal/store/opencode_store.go
+++ b/internal/store/opencode_store.go
@@ -1,0 +1,520 @@
+package store
+
+import (
+	"database/sql"
+	"fmt"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+)
+
+// OpenCodeResetCycle represents an OpenCode quota reset cycle.
+type OpenCodeResetCycle struct {
+	ID              int64
+	QuotaName       string
+	CycleStart      time.Time
+	CycleEnd        *time.Time
+	ResetsAt        *time.Time
+	PeakUtilization float64
+	TotalDelta      float64
+}
+
+func parseOpenCodeTime(value string, field string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to parse %s %q: %w", field, value, err)
+	}
+	return parsed, nil
+}
+
+// InsertOpenCodeSnapshot inserts an OpenCode snapshot with its quota values.
+func (s *Store) InsertOpenCodeSnapshot(snapshot *api.OpenCodeSnapshot) (int64, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer tx.Rollback()
+
+	result, err := tx.Exec(
+		`INSERT INTO opencode_snapshots (captured_at, workspace_id, has_monthly_usage, raw_json, quota_count) VALUES (?, ?, ?, ?, ?)`,
+		snapshot.CapturedAt.Format(time.RFC3339Nano),
+		snapshot.WorkspaceID,
+		snapshot.HasMonthlyUsage,
+		snapshot.RawJSON,
+		3, // rolling, weekly, and optionally monthly
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to insert opencode snapshot: %w", err)
+	}
+
+	snapshotID, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get snapshot ID: %w", err)
+	}
+
+	quotas := []api.OpenCodeQuota{snapshot.RollingUsage, snapshot.WeeklyUsage}
+	if snapshot.HasMonthlyUsage {
+		quotas = append(quotas, snapshot.MonthlyUsage)
+	}
+
+	for _, q := range quotas {
+		var resetsAt interface{}
+		if q.ResetsAt != nil {
+			resetsAt = q.ResetsAt.Format(time.RFC3339Nano)
+		}
+		_, err := tx.Exec(
+			`INSERT INTO opencode_quota_values (snapshot_id, quota_name, utilization, resets_at, reset_in_sec) VALUES (?, ?, ?, ?, ?)`,
+			snapshotID,
+			q.Name,
+			q.Utilization,
+			resetsAt,
+			q.ResetInSec,
+		)
+		if err != nil {
+			return 0, fmt.Errorf("failed to insert opencode quota value %s: %w", q.Name, err)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, fmt.Errorf("failed to commit: %w", err)
+	}
+
+	return snapshotID, nil
+}
+
+// QueryLatestOpenCode returns the most recent OpenCode snapshot with quotas.
+func (s *Store) QueryLatestOpenCode() (*api.OpenCodeSnapshot, error) {
+	var snapshot api.OpenCodeSnapshot
+	var capturedAt string
+
+	err := s.db.QueryRow(
+		`SELECT id, captured_at, workspace_id, has_monthly_usage, quota_count FROM opencode_snapshots ORDER BY captured_at DESC LIMIT 1`,
+	).Scan(&snapshot.ID, &capturedAt, &snapshot.WorkspaceID, &snapshot.HasMonthlyUsage, new(int))
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query latest opencode: %w", err)
+	}
+
+	parsedCapturedAt, err := parseOpenCodeTime(capturedAt, "opencode snapshot captured_at")
+	if err != nil {
+		return nil, err
+	}
+	snapshot.CapturedAt = parsedCapturedAt
+
+	rows, err := s.db.Query(
+		`SELECT quota_name, utilization, resets_at, reset_in_sec FROM opencode_quota_values WHERE snapshot_id = ? ORDER BY quota_name`,
+		snapshot.ID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query opencode quota values: %w", err)
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var q api.OpenCodeQuota
+		var resetsAt sql.NullString
+		if err := rows.Scan(&q.Name, &q.Utilization, &resetsAt, &q.ResetInSec); err != nil {
+			return nil, fmt.Errorf("failed to scan opencode quota value: %w", err)
+		}
+		if resetsAt.Valid && resetsAt.String != "" {
+			parsedResetsAt, err := parseOpenCodeTime(resetsAt.String, "opencode quota resets_at")
+			if err != nil {
+				return nil, err
+			}
+			q.ResetsAt = &parsedResetsAt
+		}
+
+		switch q.Name {
+		case "rolling":
+			snapshot.RollingUsage = q
+		case "weekly":
+			snapshot.WeeklyUsage = q
+		case "monthly":
+			snapshot.MonthlyUsage = q
+			snapshot.HasMonthlyUsage = true
+		}
+	}
+
+	return &snapshot, rows.Err()
+}
+
+// QueryOpenCodeRange returns OpenCode snapshots within a time range.
+func (s *Store) QueryOpenCodeRange(start, end time.Time, limit ...int) ([]*api.OpenCodeSnapshot, error) {
+	query := `SELECT id, captured_at, workspace_id, has_monthly_usage, quota_count FROM opencode_snapshots
+		WHERE captured_at BETWEEN ? AND ? ORDER BY captured_at ASC`
+	args := []interface{}{start.Format(time.RFC3339Nano), end.Format(time.RFC3339Nano)}
+	if len(limit) > 0 && limit[0] > 0 {
+		query = `SELECT id, captured_at, workspace_id, has_monthly_usage, quota_count
+			FROM (
+				SELECT id, captured_at, workspace_id, has_monthly_usage, quota_count
+				FROM opencode_snapshots
+				WHERE captured_at BETWEEN ? AND ?
+				ORDER BY captured_at DESC
+				LIMIT ?
+			) recent
+			ORDER BY captured_at ASC`
+		args = append(args, limit[0])
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query opencode range: %w", err)
+	}
+	defer rows.Close()
+
+	var snapshots []*api.OpenCodeSnapshot
+	for rows.Next() {
+		var snap api.OpenCodeSnapshot
+		var capturedAt string
+		if err := rows.Scan(&snap.ID, &capturedAt, &snap.WorkspaceID, &snap.HasMonthlyUsage, new(int)); err != nil {
+			return nil, fmt.Errorf("failed to scan opencode snapshot: %w", err)
+		}
+		parsedCapturedAt, err := parseOpenCodeTime(capturedAt, "opencode snapshot captured_at")
+		if err != nil {
+			return nil, err
+		}
+		snap.CapturedAt = parsedCapturedAt
+		snapshots = append(snapshots, &snap)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	for _, snap := range snapshots {
+		qRows, err := s.db.Query(
+			`SELECT quota_name, utilization, resets_at, reset_in_sec FROM opencode_quota_values WHERE snapshot_id = ? ORDER BY quota_name`,
+			snap.ID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to query opencode quota values for snapshot %d: %w", snap.ID, err)
+		}
+		for qRows.Next() {
+			var q api.OpenCodeQuota
+			var resetsAt sql.NullString
+			if err := qRows.Scan(&q.Name, &q.Utilization, &resetsAt, &q.ResetInSec); err != nil {
+				qRows.Close()
+				return nil, fmt.Errorf("failed to scan opencode quota value: %w", err)
+			}
+			if resetsAt.Valid && resetsAt.String != "" {
+				parsedResetsAt, err := parseOpenCodeTime(resetsAt.String, "opencode quota resets_at")
+				if err != nil {
+					qRows.Close()
+					return nil, err
+				}
+				q.ResetsAt = &parsedResetsAt
+			}
+
+			switch q.Name {
+			case "rolling":
+				snap.RollingUsage = q
+			case "weekly":
+				snap.WeeklyUsage = q
+			case "monthly":
+				snap.MonthlyUsage = q
+				snap.HasMonthlyUsage = true
+			}
+		}
+		qRows.Close()
+	}
+
+	return snapshots, nil
+}
+
+// CreateOpenCodeCycle creates a new OpenCode reset cycle.
+func (s *Store) CreateOpenCodeCycle(quotaName string, cycleStart time.Time, resetsAt *time.Time) (int64, error) {
+	var resetsAtVal interface{}
+	if resetsAt != nil {
+		resetsAtVal = resetsAt.Format(time.RFC3339Nano)
+	}
+
+	result, err := s.db.Exec(
+		`INSERT INTO opencode_reset_cycles (quota_name, cycle_start, resets_at) VALUES (?, ?, ?)`,
+		quotaName,
+		cycleStart.Format(time.RFC3339Nano),
+		resetsAtVal,
+	)
+	if err != nil {
+		return 0, fmt.Errorf("failed to create opencode cycle: %w", err)
+	}
+
+	id, err := result.LastInsertId()
+	if err != nil {
+		return 0, fmt.Errorf("failed to get cycle ID: %w", err)
+	}
+	return id, nil
+}
+
+// CloseOpenCodeCycle closes an OpenCode reset cycle with final stats.
+func (s *Store) CloseOpenCodeCycle(quotaName string, cycleEnd time.Time, peak, delta float64) error {
+	_, err := s.db.Exec(
+		`UPDATE opencode_reset_cycles SET cycle_end = ?, peak_utilization = ?, total_delta = ?
+		WHERE quota_name = ? AND cycle_end IS NULL`,
+		cycleEnd.Format(time.RFC3339Nano),
+		peak,
+		delta,
+		quotaName,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to close opencode cycle: %w", err)
+	}
+	return nil
+}
+
+// UpdateOpenCodeCycle updates the peak and delta for an active OpenCode cycle.
+func (s *Store) UpdateOpenCodeCycle(quotaName string, peak, delta float64) error {
+	_, err := s.db.Exec(
+		`UPDATE opencode_reset_cycles SET peak_utilization = ?, total_delta = ?
+		WHERE quota_name = ? AND cycle_end IS NULL`,
+		peak,
+		delta,
+		quotaName,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update opencode cycle: %w", err)
+	}
+	return nil
+}
+
+// UpdateOpenCodeCycleResetsAt updates the reset timestamp for an active OpenCode cycle.
+func (s *Store) UpdateOpenCodeCycleResetsAt(quotaName string, resetsAt *time.Time) error {
+	var resetsAtValue interface{}
+	if resetsAt != nil {
+		resetsAtValue = resetsAt.Format(time.RFC3339Nano)
+	}
+
+	_, err := s.db.Exec(
+		`UPDATE opencode_reset_cycles SET resets_at = ?
+		WHERE quota_name = ? AND cycle_end IS NULL`,
+		resetsAtValue,
+		quotaName,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to update opencode cycle resets_at: %w", err)
+	}
+	return nil
+}
+
+// QueryActiveOpenCodeCycle returns the active cycle for an OpenCode quota.
+func (s *Store) QueryActiveOpenCodeCycle(quotaName string) (*OpenCodeResetCycle, error) {
+	var cycle OpenCodeResetCycle
+	var cycleStart string
+	var cycleEnd, resetsAt sql.NullString
+
+	err := s.db.QueryRow(
+		`SELECT id, quota_name, cycle_start, cycle_end, resets_at, peak_utilization, total_delta
+		FROM opencode_reset_cycles WHERE quota_name = ? AND cycle_end IS NULL`,
+		quotaName,
+	).Scan(
+		&cycle.ID,
+		&cycle.QuotaName,
+		&cycleStart,
+		&cycleEnd,
+		&resetsAt,
+		&cycle.PeakUtilization,
+		&cycle.TotalDelta,
+	)
+
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to query active opencode cycle: %w", err)
+	}
+
+	parsedCycleStart, err := parseOpenCodeTime(cycleStart, "opencode cycle_start")
+	if err != nil {
+		return nil, err
+	}
+	cycle.CycleStart = parsedCycleStart
+	if cycleEnd.Valid {
+		parsedCycleEnd, err := parseOpenCodeTime(cycleEnd.String, "opencode cycle_end")
+		if err != nil {
+			return nil, err
+		}
+		cycle.CycleEnd = &parsedCycleEnd
+	}
+	if resetsAt.Valid {
+		parsedResetsAt, err := parseOpenCodeTime(resetsAt.String, "opencode cycle resets_at")
+		if err != nil {
+			return nil, err
+		}
+		cycle.ResetsAt = &parsedResetsAt
+	}
+
+	return &cycle, nil
+}
+
+// QueryOpenCodeCycleHistory returns completed cycles for an OpenCode quota with optional limit.
+func (s *Store) QueryOpenCodeCycleHistory(quotaName string, limit ...int) ([]*OpenCodeResetCycle, error) {
+	query := `SELECT id, quota_name, cycle_start, cycle_end, resets_at, peak_utilization, total_delta
+		FROM opencode_reset_cycles WHERE quota_name = ? AND cycle_end IS NOT NULL ORDER BY cycle_start DESC`
+	args := []interface{}{quotaName}
+	if len(limit) > 0 && limit[0] > 0 {
+		query += ` LIMIT ?`
+		args = append(args, limit[0])
+	}
+
+	rows, err := s.db.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query opencode cycles: %w", err)
+	}
+	defer rows.Close()
+
+	var cycles []*OpenCodeResetCycle
+	for rows.Next() {
+		var cycle OpenCodeResetCycle
+		var cycleStart, cycleEnd string
+		var resetsAt sql.NullString
+
+		if err := rows.Scan(
+			&cycle.ID,
+			&cycle.QuotaName,
+			&cycleStart,
+			&cycleEnd,
+			&resetsAt,
+			&cycle.PeakUtilization,
+			&cycle.TotalDelta,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan opencode cycle: %w", err)
+		}
+
+		parsedCycleStart, err := parseOpenCodeTime(cycleStart, "opencode cycle_start")
+		if err != nil {
+			return nil, err
+		}
+		cycle.CycleStart = parsedCycleStart
+
+		parsedCycleEnd, err := parseOpenCodeTime(cycleEnd, "opencode cycle_end")
+		if err != nil {
+			return nil, err
+		}
+		cycle.CycleEnd = &parsedCycleEnd
+		if resetsAt.Valid {
+			parsedResetsAt, err := parseOpenCodeTime(resetsAt.String, "opencode cycle resets_at")
+			if err != nil {
+				return nil, err
+			}
+			cycle.ResetsAt = &parsedResetsAt
+		}
+
+		cycles = append(cycles, &cycle)
+	}
+
+	return cycles, rows.Err()
+}
+
+// QueryOpenCodeCyclesSince returns completed cycles for a quota since a given time.
+func (s *Store) QueryOpenCodeCyclesSince(quotaName string, since time.Time) ([]*OpenCodeResetCycle, error) {
+	rows, err := s.db.Query(
+		`SELECT id, quota_name, cycle_start, cycle_end, resets_at, peak_utilization, total_delta
+		FROM opencode_reset_cycles WHERE quota_name = ? AND cycle_end IS NOT NULL AND cycle_start >= ?
+		ORDER BY cycle_start DESC`,
+		quotaName,
+		since.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query opencode cycles since: %w", err)
+	}
+	defer rows.Close()
+
+	var cycles []*OpenCodeResetCycle
+	for rows.Next() {
+		var cycle OpenCodeResetCycle
+		var cycleStart, cycleEnd string
+		var resetsAt sql.NullString
+
+		if err := rows.Scan(
+			&cycle.ID,
+			&cycle.QuotaName,
+			&cycleStart,
+			&cycleEnd,
+			&resetsAt,
+			&cycle.PeakUtilization,
+			&cycle.TotalDelta,
+		); err != nil {
+			return nil, fmt.Errorf("failed to scan opencode cycle: %w", err)
+		}
+
+		parsedCycleStart, err := parseOpenCodeTime(cycleStart, "opencode cycle_start")
+		if err != nil {
+			return nil, err
+		}
+		cycle.CycleStart = parsedCycleStart
+
+		parsedCycleEnd, err := parseOpenCodeTime(cycleEnd, "opencode cycle_end")
+		if err != nil {
+			return nil, err
+		}
+		cycle.CycleEnd = &parsedCycleEnd
+		if resetsAt.Valid {
+			parsedResetsAt, err := parseOpenCodeTime(resetsAt.String, "opencode cycle resets_at")
+			if err != nil {
+				return nil, err
+			}
+			cycle.ResetsAt = &parsedResetsAt
+		}
+
+		cycles = append(cycles, &cycle)
+	}
+
+	return cycles, rows.Err()
+}
+
+// QueryOpenCodeUtilizationSeries returns per-quota utilization points since a given time.
+func (s *Store) QueryOpenCodeUtilizationSeries(quotaName string, since time.Time) ([]UtilizationPoint, error) {
+	rows, err := s.db.Query(
+		`SELECT s.captured_at, qv.utilization
+		FROM opencode_quota_values qv
+		JOIN opencode_snapshots s ON s.id = qv.snapshot_id
+		WHERE qv.quota_name = ? AND s.captured_at >= ?
+		ORDER BY s.captured_at ASC`,
+		quotaName,
+		since.UTC().Format(time.RFC3339Nano),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query opencode utilization series: %w", err)
+	}
+	defer rows.Close()
+
+	var points []UtilizationPoint
+	for rows.Next() {
+		var capturedAt string
+		var util float64
+		if err := rows.Scan(&capturedAt, &util); err != nil {
+			return nil, fmt.Errorf("failed to scan opencode utilization point: %w", err)
+		}
+		parsedCapturedAt, err := parseOpenCodeTime(capturedAt, "opencode utilization captured_at")
+		if err != nil {
+			return nil, err
+		}
+		points = append(points, UtilizationPoint{CapturedAt: parsedCapturedAt, Utilization: util})
+	}
+
+	return points, rows.Err()
+}
+
+// QueryAllOpenCodeQuotaNames returns all distinct quota names from OpenCode quota values.
+func (s *Store) QueryAllOpenCodeQuotaNames() ([]string, error) {
+	rows, err := s.db.Query(
+		`SELECT DISTINCT quota_name FROM opencode_quota_values ORDER BY quota_name`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query opencode quota names: %w", err)
+	}
+	defer rows.Close()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("failed to scan opencode quota name: %w", err)
+		}
+		names = append(names, name)
+	}
+
+	return names, rows.Err()
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -699,6 +699,42 @@ func (s *Store) createTables() error {
 			partial_line TEXT NOT NULL DEFAULT '',
 			updated_at TEXT NOT NULL
 		);
+
+		-- OpenCode tables
+		CREATE TABLE IF NOT EXISTS opencode_snapshots (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			captured_at TEXT NOT NULL,
+			workspace_id TEXT NOT NULL,
+			has_monthly_usage INTEGER NOT NULL DEFAULT 0,
+			raw_json TEXT NOT NULL DEFAULT '',
+			quota_count INTEGER NOT NULL DEFAULT 0
+		);
+
+		CREATE TABLE IF NOT EXISTS opencode_quota_values (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			snapshot_id INTEGER NOT NULL,
+			quota_name TEXT NOT NULL,
+			utilization REAL NOT NULL DEFAULT 0,
+			resets_at TEXT,
+			reset_in_sec INTEGER NOT NULL DEFAULT 0,
+			FOREIGN KEY (snapshot_id) REFERENCES opencode_snapshots(id)
+		);
+
+		CREATE TABLE IF NOT EXISTS opencode_reset_cycles (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			quota_name TEXT NOT NULL,
+			cycle_start TEXT NOT NULL,
+			cycle_end TEXT,
+			resets_at TEXT,
+			peak_utilization REAL NOT NULL DEFAULT 0,
+			total_delta REAL NOT NULL DEFAULT 0
+		);
+
+		-- OpenCode indexes
+		CREATE INDEX IF NOT EXISTS idx_opencode_snapshots_captured ON opencode_snapshots(captured_at);
+		CREATE INDEX IF NOT EXISTS idx_opencode_quota_values_snapshot ON opencode_quota_values(snapshot_id);
+		CREATE INDEX IF NOT EXISTS idx_opencode_cycles_name_start ON opencode_reset_cycles(quota_name, cycle_start);
+		CREATE INDEX IF NOT EXISTS idx_opencode_cycles_name_active ON opencode_reset_cycles(quota_name, cycle_end) WHERE cycle_end IS NULL;
 	`
 
 	if _, err := s.db.Exec(schema); err != nil {

--- a/internal/tracker/opencode_tracker.go
+++ b/internal/tracker/opencode_tracker.go
@@ -1,0 +1,317 @@
+package tracker
+
+import (
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+	"github.com/onllm-dev/onwatch/v2/internal/store"
+)
+
+type OpenCodeTracker struct {
+	store      *store.Store
+	logger     *slog.Logger
+	lastValues map[string]float64
+	lastResets map[string]string
+	hasLast    bool
+	onReset    func(quotaName string)
+}
+
+func (t *OpenCodeTracker) SetOnReset(fn func(string)) {
+	t.onReset = fn
+}
+
+type OpenCodeSummary struct {
+	QuotaName       string
+	CurrentUtil     float64
+	ResetsAt        *time.Time
+	TimeUntilReset  time.Duration
+	CurrentRate     float64
+	ProjectedUtil   float64
+	CompletedCycles int
+	AvgPerCycle     float64
+	PeakCycle       float64
+	TotalTracked    float64
+	TrackingSince   time.Time
+}
+
+func NewOpenCodeTracker(store *store.Store, logger *slog.Logger) *OpenCodeTracker {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &OpenCodeTracker{
+		store:      store,
+		logger:     logger,
+		lastValues: make(map[string]float64),
+		lastResets: make(map[string]string),
+	}
+}
+
+func (t *OpenCodeTracker) Process(snapshot *api.OpenCodeSnapshot) error {
+	quotas := []api.OpenCodeQuota{snapshot.RollingUsage, snapshot.WeeklyUsage}
+	if snapshot.HasMonthlyUsage {
+		quotas = append(quotas, snapshot.MonthlyUsage)
+	}
+
+	for _, quota := range quotas {
+		if err := t.processQuota(quota, snapshot.CapturedAt); err != nil {
+			return fmt.Errorf("opencode tracker: %s: %w", quota.Name, err)
+		}
+	}
+
+	t.hasLast = true
+	return nil
+}
+
+func (t *OpenCodeTracker) processQuota(quota api.OpenCodeQuota, capturedAt time.Time) error {
+	quotaName := quota.Name
+	currentUtil := normalizeOpenCodeTrackerUtilization(quota.Utilization)
+
+	cycle, err := t.store.QueryActiveOpenCodeCycle(quotaName)
+	if err != nil {
+		return fmt.Errorf("failed to query active cycle: %w", err)
+	}
+
+	if cycle == nil {
+		_, err := t.store.CreateOpenCodeCycle(quotaName, capturedAt, quota.ResetsAt)
+		if err != nil {
+			return fmt.Errorf("failed to create cycle: %w", err)
+		}
+		if err := t.store.UpdateOpenCodeCycle(quotaName, currentUtil, 0); err != nil {
+			return fmt.Errorf("failed to set initial peak: %w", err)
+		}
+		t.lastValues[quotaName] = currentUtil
+		if quota.ResetsAt != nil {
+			t.lastResets[quotaName] = quota.ResetsAt.Format(time.RFC3339Nano)
+		}
+		t.logger.Info("Created new OpenCode cycle",
+			"quota", quotaName,
+			"resetsAt", quota.ResetsAt,
+			"initialUtil", currentUtil,
+		)
+		return nil
+	}
+
+	resetDetected := false
+	resetReason := ""
+	if cycle.ResetsAt != nil && capturedAt.After(cycle.ResetsAt.Add(2*time.Minute)) {
+		resetDetected = true
+		resetReason = "time-based (stored ResetsAt passed)"
+	}
+
+	if !resetDetected {
+		if quota.ResetsAt != nil && cycle.ResetsAt != nil {
+			diff := quota.ResetsAt.Sub(*cycle.ResetsAt)
+			if diff < 0 {
+				diff = -diff
+			}
+			if diff > 10*time.Minute {
+				resetDetected = true
+				resetReason = "api-based (ResetsAt changed)"
+			}
+		} else if quota.ResetsAt != nil && cycle.ResetsAt == nil {
+			resetDetected = true
+			resetReason = "api-based (new ResetsAt appeared)"
+		}
+	}
+
+	if resetDetected {
+		cycleEndTime := capturedAt
+		if cycle.ResetsAt != nil && capturedAt.After(*cycle.ResetsAt) {
+			cycleEndTime = *cycle.ResetsAt
+		}
+
+		if t.hasLast {
+			if lastUtil, ok := t.lastValues[quotaName]; ok {
+				delta := currentUtil - lastUtil
+				if delta > 0 {
+					cycle.TotalDelta += delta
+				}
+				if currentUtil > cycle.PeakUtilization {
+					cycle.PeakUtilization = currentUtil
+				}
+			}
+		}
+
+		if err := t.store.CloseOpenCodeCycle(quotaName, cycleEndTime, cycle.PeakUtilization, cycle.TotalDelta); err != nil {
+			return fmt.Errorf("failed to close cycle: %w", err)
+		}
+
+		if _, err := t.store.CreateOpenCodeCycle(quotaName, capturedAt, quota.ResetsAt); err != nil {
+			return fmt.Errorf("failed to create new cycle: %w", err)
+		}
+		if err := t.store.UpdateOpenCodeCycle(quotaName, currentUtil, 0); err != nil {
+			return fmt.Errorf("failed to set initial peak: %w", err)
+		}
+
+		t.lastValues[quotaName] = currentUtil
+		if quota.ResetsAt != nil {
+			t.lastResets[quotaName] = quota.ResetsAt.Format(time.RFC3339Nano)
+		}
+		t.logger.Info("Detected OpenCode quota reset",
+			"quota", quotaName,
+			"reason", resetReason,
+			"oldResetsAt", cycle.ResetsAt,
+			"newResetsAt", quota.ResetsAt,
+			"cycleEndTime", cycleEndTime,
+			"totalDelta", cycle.TotalDelta,
+		)
+		if t.onReset != nil {
+			t.onReset(quotaName)
+		}
+		return nil
+	}
+
+	if t.hasLast {
+		if lastUtil, ok := t.lastValues[quotaName]; ok {
+			delta := currentUtil - lastUtil
+			if delta > 0 {
+				cycle.TotalDelta += delta
+			}
+			if currentUtil > cycle.PeakUtilization {
+				cycle.PeakUtilization = currentUtil
+			}
+			if err := t.store.UpdateOpenCodeCycle(quotaName, cycle.PeakUtilization, cycle.TotalDelta); err != nil {
+				return fmt.Errorf("failed to update cycle: %w", err)
+			}
+		} else {
+			if currentUtil > cycle.PeakUtilization {
+				cycle.PeakUtilization = currentUtil
+				if err := t.store.UpdateOpenCodeCycle(quotaName, cycle.PeakUtilization, cycle.TotalDelta); err != nil {
+					return fmt.Errorf("failed to update cycle: %w", err)
+				}
+			}
+		}
+	} else {
+		if currentUtil > cycle.PeakUtilization {
+			cycle.PeakUtilization = currentUtil
+			if err := t.store.UpdateOpenCodeCycle(quotaName, cycle.PeakUtilization, cycle.TotalDelta); err != nil {
+				return fmt.Errorf("failed to update cycle: %w", err)
+			}
+		}
+	}
+
+	t.lastValues[quotaName] = currentUtil
+	if quota.ResetsAt != nil {
+		t.lastResets[quotaName] = quota.ResetsAt.Format(time.RFC3339Nano)
+	}
+	return nil
+}
+
+func (t *OpenCodeTracker) UsageSummary(quotaName string) (*OpenCodeSummary, error) {
+	canonicalQuotaName := normalizeOpenCodeQuotaName(quotaName)
+
+	activeCycle, err := t.store.QueryActiveOpenCodeCycle(canonicalQuotaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query active cycle: %w", err)
+	}
+
+	history, err := t.store.QueryOpenCodeCycleHistory(canonicalQuotaName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query cycle history: %w", err)
+	}
+
+	summary := &OpenCodeSummary{
+		QuotaName:       canonicalQuotaName,
+		CompletedCycles: len(history),
+	}
+
+	if len(history) > 0 {
+		var totalDelta float64
+		summary.TrackingSince = history[len(history)-1].CycleStart
+
+		for _, cycle := range history {
+			totalDelta += cycle.TotalDelta
+			if cycle.PeakUtilization > summary.PeakCycle {
+				summary.PeakCycle = cycle.PeakUtilization
+			}
+		}
+		summary.AvgPerCycle = totalDelta / float64(len(history))
+		summary.TotalTracked = totalDelta
+	}
+
+	if activeCycle != nil {
+		summary.TotalTracked += activeCycle.TotalDelta
+		if activeCycle.PeakUtilization > summary.PeakCycle {
+			summary.PeakCycle = activeCycle.PeakUtilization
+		}
+		if activeCycle.ResetsAt != nil {
+			summary.ResetsAt = activeCycle.ResetsAt
+			summary.TimeUntilReset = time.Until(*activeCycle.ResetsAt)
+		}
+
+		latest, err := t.store.QueryLatestOpenCode()
+		if err != nil {
+			return nil, fmt.Errorf("failed to query latest: %w", err)
+		}
+
+		if latest != nil {
+			quota := getOpenCodeQuotaByName(latest, canonicalQuotaName)
+			if quota != nil {
+				summary.CurrentUtil = normalizeOpenCodeTrackerUtilization(quota.Utilization)
+				if summary.ResetsAt == nil && quota.ResetsAt != nil {
+					summary.ResetsAt = quota.ResetsAt
+					summary.TimeUntilReset = time.Until(*quota.ResetsAt)
+				}
+			}
+
+			elapsed := time.Since(activeCycle.CycleStart)
+			if elapsed.Minutes() >= 30 && activeCycle.TotalDelta > 0 {
+				summary.CurrentRate = activeCycle.TotalDelta / elapsed.Hours()
+				if summary.ResetsAt != nil {
+					hoursLeft := time.Until(*summary.ResetsAt).Hours()
+					if hoursLeft > 0 {
+						projected := summary.CurrentUtil + (summary.CurrentRate * hoursLeft)
+						if projected > 1 {
+							projected = 1
+						}
+						summary.ProjectedUtil = projected
+					}
+				}
+			}
+		}
+	}
+
+	return summary, nil
+}
+
+func getOpenCodeQuotaByName(snapshot *api.OpenCodeSnapshot, name string) *api.OpenCodeQuota {
+	switch name {
+	case "rolling", "rolling_usage":
+		return &snapshot.RollingUsage
+	case "weekly", "weekly_usage":
+		return &snapshot.WeeklyUsage
+	case "monthly", "monthly_usage":
+		if snapshot.HasMonthlyUsage {
+			return &snapshot.MonthlyUsage
+		}
+	}
+	return nil
+}
+
+func normalizeOpenCodeTrackerUtilization(utilization float64) float64 {
+	switch {
+	case utilization < 0:
+		return 0
+	case utilization > 100:
+		return 1
+	case utilization > 1:
+		return utilization / 100
+	default:
+		return utilization
+	}
+}
+
+func normalizeOpenCodeQuotaName(name string) string {
+	switch name {
+	case "rolling", "rolling_usage":
+		return "rolling"
+	case "weekly", "weekly_usage":
+		return "weekly"
+	case "monthly", "monthly_usage":
+		return "monthly"
+	default:
+		return name
+	}
+}

--- a/internal/tracker/opencode_tracker_test.go
+++ b/internal/tracker/opencode_tracker_test.go
@@ -1,0 +1,91 @@
+package tracker
+
+import (
+	"math"
+	"testing"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+	"github.com/onllm-dev/onwatch/v2/internal/store"
+)
+
+func TestNormalizeOpenCodeTrackerUtilization(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name  string
+		input float64
+		want  float64
+	}{
+		{name: "negative", input: -5, want: 0},
+		{name: "fraction", input: 0.82, want: 0.82},
+		{name: "one_is_full", input: 1, want: 1},
+		{name: "percent_scale", input: 82, want: 0.82},
+		{name: "over_100_clamped", input: 150, want: 1},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeOpenCodeTrackerUtilization(tc.input)
+			if math.Abs(got-tc.want) > 1e-9 {
+				t.Fatalf("normalizeOpenCodeTrackerUtilization(%v) = %v, want %v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestOpenCodeTrackerUsageSummary_ClampsProjectedUtilAndHandlesQuotaAlias(t *testing.T) {
+	t.Parallel()
+
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	now := time.Now().UTC()
+	resetAt := now.Add(1 * time.Hour)
+	cycleStart := now.Add(-2 * time.Hour)
+
+	if _, err := s.CreateOpenCodeCycle("rolling", cycleStart, &resetAt); err != nil {
+		t.Fatalf("CreateOpenCodeCycle: %v", err)
+	}
+	// 0.95 current + (0.5 delta / 2h * 1h left) = 1.20 -> must clamp to 1.0
+	if err := s.UpdateOpenCodeCycle("rolling", 0.95, 0.5); err != nil {
+		t.Fatalf("UpdateOpenCodeCycle: %v", err)
+	}
+
+	_, err = s.InsertOpenCodeSnapshot(&api.OpenCodeSnapshot{
+		CapturedAt:  now,
+		WorkspaceID: "wrk_test",
+		RollingUsage: api.OpenCodeQuota{
+			Name:        "rolling",
+			Utilization: 0.95,
+			ResetsAt:    &resetAt,
+		},
+		WeeklyUsage: api.OpenCodeQuota{
+			Name:        "weekly",
+			Utilization: 0.15,
+		},
+	})
+	if err != nil {
+		t.Fatalf("InsertOpenCodeSnapshot: %v", err)
+	}
+
+	tr := NewOpenCodeTracker(s, nil)
+	summary, err := tr.UsageSummary("rolling_usage")
+	if err != nil {
+		t.Fatalf("UsageSummary: %v", err)
+	}
+	if summary == nil {
+		t.Fatal("expected non-nil summary")
+	}
+	if summary.QuotaName != "rolling" {
+		t.Fatalf("QuotaName = %q, want rolling", summary.QuotaName)
+	}
+	if summary.ProjectedUtil != 1 {
+		t.Fatalf("ProjectedUtil = %v, want 1", summary.ProjectedUtil)
+	}
+}

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -92,6 +92,7 @@ type Handler struct {
 	geminiTracker      *tracker.GeminiTracker
 	openrouterTracker  *tracker.OpenRouterTracker
 	cursorTracker      *tracker.CursorTracker
+	opencodeTracker    *tracker.OpenCodeTracker
 	updater            *update.Updater
 	notifier           Notifier
 	agentManager       ProviderAgentController
@@ -817,6 +818,11 @@ func (h *Handler) SetCursorTracker(t *tracker.CursorTracker) {
 	h.cursorTracker = t
 }
 
+// SetOpenCodeTracker sets the OpenCode tracker for usage summary enrichment.
+func (h *Handler) SetOpenCodeTracker(t *tracker.OpenCodeTracker) {
+	h.opencodeTracker = t
+}
+
 // SetAgentManager sets provider agent lifecycle controller.
 func (h *Handler) SetAgentManager(m ProviderAgentController) {
 	h.agentManager = m
@@ -1152,6 +1158,7 @@ func providerCatalog() []providerCatalogItem {
 		{Key: "openrouter", Name: "OpenRouter", Description: "OpenRouter credits usage tracking"},
 		{Key: "gemini", Name: "Gemini", Description: "Google Gemini CLI quota tracking", AutoDetectable: true},
 		{Key: "cursor", Name: "Cursor", Description: "Cursor usage and quota tracking", AutoDetectable: true},
+		{Key: "opencode", Name: "OpenCode GO", Description: "OpenCode GO usage tracking", AutoDetectable: true},
 	}
 }
 
@@ -1211,6 +1218,8 @@ func (h *Handler) isProviderConfigured(provider string) bool {
 		return h.config.GeminiEnabled
 	case "cursor":
 		return strings.TrimSpace(h.config.CursorToken) != "" || strings.TrimSpace(api.DetectCursorToken(h.logger)) != ""
+	case "opencode":
+		return strings.TrimSpace(h.config.OpenCodeCookie) != "" || strings.TrimSpace(api.DetectOpenCodeCookie(h.logger)) != ""
 	default:
 		return false
 	}
@@ -1340,6 +1349,8 @@ func applyProviderConfig(dst, src *config.Config) {
 	dst.OpenRouterAPIKey = src.OpenRouterAPIKey
 	dst.GeminiEnabled = src.GeminiEnabled
 	dst.GeminiAutoToken = src.GeminiAutoToken
+	dst.OpenCodeCookie = src.OpenCodeCookie
+	dst.OpenCodeAutoCookie = src.OpenCodeAutoCookie
 	dst.ZaiRegion = src.ZaiRegion
 	dst.MiniMaxRegion = src.MiniMaxRegion
 }
@@ -1350,6 +1361,7 @@ func applyProviderConfig(dst, src *config.Config) {
 // without exposing the actual values.
 var providerSecretKeys = map[string]bool{
 	"api_key":    true,
+	"cookie":     true,
 	"token":      true,
 	"csrf_token": true,
 }
@@ -1467,6 +1479,12 @@ func ApplyProviderSettingsFromDB(st *store.Store, cfg *config.Config, logger *sl
 	if s := provSettings["openrouter"]; s != nil {
 		if key, _ := s["api_key"].(string); key != "" {
 			cfg.OpenRouterAPIKey = key
+		}
+	}
+	if s := provSettings["opencode"]; s != nil {
+		if cookie, _ := s["cookie"].(string); cookie != "" {
+			cfg.OpenCodeCookie = api.NormalizeOpenCodeCookie(cookie)
+			cfg.OpenCodeAutoCookie = false
 		}
 	}
 	if s := provSettings["antigravity"]; s != nil {
@@ -1809,6 +1827,8 @@ func (h *Handler) Current(w http.ResponseWriter, r *http.Request) {
 		h.currentGemini(w, r)
 	case "cursor":
 		h.currentCursor(w, r)
+	case "opencode":
+		h.currentOpenCode(w, r)
 	default:
 		respondError(w, http.StatusBadRequest, fmt.Sprintf("unknown provider: %s", provider))
 	}
@@ -1886,6 +1906,9 @@ func (h *Handler) currentBoth(w http.ResponseWriter, r *http.Request) {
 	}
 	if h.config.HasProvider("cursor") && providerTelemetryEnabled(visibility, "cursor") {
 		response["cursor"] = h.buildCursorCurrent()
+	}
+	if h.config.HasProvider("opencode") && providerTelemetryEnabled(visibility, "opencode") {
+		response["opencode"] = h.buildOpenCodeCurrent()
 	}
 	respondJSON(w, http.StatusOK, response)
 }
@@ -2227,6 +2250,8 @@ func (h *Handler) History(w http.ResponseWriter, r *http.Request) {
 		h.historyGemini(w, r)
 	case "cursor":
 		h.historyCursor(w, r)
+	case "opencode":
+		h.historyOpenCode(w, r)
 	default:
 		respondError(w, http.StatusBadRequest, fmt.Sprintf("unknown provider: %s", provider))
 	}
@@ -2541,6 +2566,30 @@ func (h *Handler) historyBoth(w http.ResponseWriter, r *http.Request) {
 				cursorData = append(cursorData, entry)
 			}
 			response["cursor"] = cursorData
+		}
+	}
+
+	if h.config.HasProvider("opencode") && providerTelemetryEnabled(visibility, "opencode") && h.store != nil {
+		snapshots, err := h.store.QueryOpenCodeRange(start, now)
+		if err == nil {
+			step := downsampleStep(len(snapshots), maxChartPoints)
+			last := len(snapshots) - 1
+			opencodeData := make([]map[string]interface{}, 0, min(len(snapshots), maxChartPoints))
+			for i, snap := range snapshots {
+				if step > 1 && i != 0 && i != last && i%step != 0 {
+					continue
+				}
+				entry := map[string]interface{}{
+					"capturedAt":    snap.CapturedAt.Format(time.RFC3339),
+					"rolling_usage": snap.RollingUsage.Utilization * 100,
+					"weekly_usage":  snap.WeeklyUsage.Utilization * 100,
+				}
+				if snap.HasMonthlyUsage {
+					entry["monthly_usage"] = snap.MonthlyUsage.Utilization * 100
+				}
+				opencodeData = append(opencodeData, entry)
+			}
+			response["opencode"] = opencodeData
 		}
 	}
 
@@ -3108,6 +3157,185 @@ func (h *Handler) loggingHistoryOpenRouter(w http.ResponseWriter, r *http.Reques
 		"provider":   "openrouter",
 		"quotaNames": quotaNames,
 		"logs":       logs,
+	})
+}
+
+// loggingHistoryOpenCode returns OpenCode polling history.
+func (h *Handler) loggingHistoryOpenCode(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		respondJSON(w, http.StatusOK, map[string]interface{}{
+			"provider":   "opencode",
+			"quotaNames": []string{},
+			"logs":       []interface{}{},
+		})
+		return
+	}
+
+	start, end, limit := h.loggingHistoryRangeAndLimit(r)
+	snapshots, err := h.store.QueryOpenCodeRange(start, end, limit)
+	if err != nil {
+		h.logger.Error("failed to query OpenCode logging history", "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to query logging history")
+		return
+	}
+
+	// Build quotaNames from ALL snapshots
+	quotaNameSet := map[string]bool{
+		"rolling_usage": true,
+		"weekly_usage":  true,
+	}
+	for _, snap := range snapshots {
+		if snap.HasMonthlyUsage {
+			quotaNameSet["monthly_usage"] = true
+		}
+	}
+
+	var quotaNames []string
+	for name := range quotaNameSet {
+		quotaNames = append(quotaNames, name)
+	}
+
+	var logs []map[string]interface{}
+	for _, snap := range snapshots {
+		log := map[string]interface{}{
+			"capturedAt":  snap.CapturedAt.Format(time.RFC3339),
+			"workspaceId": snap.WorkspaceID,
+			"quotaValues": map[string]interface{}{},
+		}
+
+		rollingValues := map[string]interface{}{
+			"quotaName":    "rolling_usage",
+			"utilization":  normalizeOpenCodeUtilization(snap.RollingUsage.Utilization),
+			"usagePercent": openCodeUsagePercent(snap.RollingUsage.Utilization),
+		}
+		if snap.RollingUsage.ResetsAt != nil {
+			rollingValues["resetTime"] = snap.RollingUsage.ResetsAt.Format(time.RFC3339)
+		}
+		if snap.RollingUsage.ResetInSec > 0 {
+			rollingValues["resetInSec"] = snap.RollingUsage.ResetInSec
+		}
+		log["quotaValues"].(map[string]interface{})["rolling_usage"] = rollingValues
+
+		weeklyValues := map[string]interface{}{
+			"quotaName":    "weekly_usage",
+			"utilization":  normalizeOpenCodeUtilization(snap.WeeklyUsage.Utilization),
+			"usagePercent": openCodeUsagePercent(snap.WeeklyUsage.Utilization),
+		}
+		if snap.WeeklyUsage.ResetsAt != nil {
+			weeklyValues["resetTime"] = snap.WeeklyUsage.ResetsAt.Format(time.RFC3339)
+		}
+		if snap.WeeklyUsage.ResetInSec > 0 {
+			weeklyValues["resetInSec"] = snap.WeeklyUsage.ResetInSec
+		}
+		log["quotaValues"].(map[string]interface{})["weekly_usage"] = weeklyValues
+
+		if snap.HasMonthlyUsage {
+			monthlyValues := map[string]interface{}{
+				"quotaName":    "monthly_usage",
+				"utilization":  normalizeOpenCodeUtilization(snap.MonthlyUsage.Utilization),
+				"usagePercent": openCodeUsagePercent(snap.MonthlyUsage.Utilization),
+			}
+			if snap.MonthlyUsage.ResetsAt != nil {
+				monthlyValues["resetTime"] = snap.MonthlyUsage.ResetsAt.Format(time.RFC3339)
+			}
+			if snap.MonthlyUsage.ResetInSec > 0 {
+				monthlyValues["resetInSec"] = snap.MonthlyUsage.ResetInSec
+			}
+			log["quotaValues"].(map[string]interface{})["monthly_usage"] = monthlyValues
+		}
+
+		logs = append(logs, log)
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"provider":   "opencode",
+		"quotaNames": quotaNames,
+		"logs":       logs,
+	})
+}
+
+// TestProvider tests a provider's configuration and returns diagnostic information
+func (h *Handler) TestProvider(w http.ResponseWriter, r *http.Request) {
+	provider := r.URL.Query().Get("provider")
+	if provider == "" {
+		respondError(w, http.StatusBadRequest, "provider parameter is required")
+		return
+	}
+
+	h.logger.Info("testProvider called", "provider", provider)
+
+	switch provider {
+	case "opencode":
+		h.testOpenCode(w, r)
+	default:
+		respondError(w, http.StatusBadRequest, fmt.Sprintf("unknown provider: %s", provider))
+	}
+}
+
+// testOpenCode tests OpenCode configuration and returns diagnostic information
+func (h *Handler) testOpenCode(w http.ResponseWriter, r *http.Request) {
+	h.logger.Info("Testing OpenCode configuration")
+
+	// Check if OpenCode is configured
+	cookie := h.config.OpenCodeCookie
+	autoCookie := h.config.OpenCodeAutoCookie
+
+	h.logger.Info("OpenCode configuration check",
+		"cookie_set", cookie != "",
+		"auto_detected", autoCookie,
+		"cookie_length", len(cookie),
+	)
+
+	if cookie == "" {
+		// Try to detect cookie
+		detected := api.DetectOpenCodeCookie(h.logger)
+		h.logger.Info("Auto-detection attempt", "detected", detected != "")
+		if detected != "" {
+			respondJSON(w, http.StatusOK, map[string]interface{}{
+				"message":       "OpenCode GO cookie auto-detected from OPENCODE_COOKIE environment variable",
+				"cookie_length": len(detected),
+				"auto_detected": true,
+			})
+			return
+		}
+		respondError(w, http.StatusBadRequest, "OpenCode GO cookie not configured. In Settings > OpenCode GO, copy auth from DevTools > Application > Cookies > https://opencode.ai and paste it into auth Cookie Value.")
+		return
+	}
+
+	// Try to create a client and fetch quotas
+	client := api.NewOpenCodeClient(cookie, h.logger)
+
+	h.logger.Info("OpenCode client created successfully")
+
+	// Test quota fetch
+	ctx := context.Background()
+	snapshot, err := client.FetchQuotas(ctx, "")
+	if err != nil {
+		h.logger.Error("Failed to fetch quotas", "error", err)
+		respondError(w, http.StatusInternalServerError, fmt.Sprintf("Failed to fetch quotas: %v", err))
+		return
+	}
+
+	h.logger.Info("Quotas fetched successfully",
+		"workspace_id", snapshot.WorkspaceID,
+		"rolling_utilization", snapshot.RollingUsage.Utilization,
+		"weekly_utilization", snapshot.WeeklyUsage.Utilization,
+		"has_monthly", snapshot.HasMonthlyUsage,
+	)
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{
+		"message":       "OpenCode GO configuration is valid",
+		"workspace_id":  snapshot.WorkspaceID,
+		"rolling_usage": snapshot.RollingUsage.Utilization,
+		"weekly_usage":  snapshot.WeeklyUsage.Utilization,
+		"monthly_usage": func() float64 {
+			if snapshot.HasMonthlyUsage {
+				return snapshot.MonthlyUsage.Utilization
+			}
+			return 0
+		}(),
+		"has_monthly":   snapshot.HasMonthlyUsage,
+		"auto_detected": autoCookie,
 	})
 }
 
@@ -6226,7 +6454,15 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 			respondError(w, http.StatusInternalServerError, "failed to save provider settings")
 			return
 		}
-		h.logger.Info("Provider settings updated", "providers", provSettings)
+		updatedProviders := make([]string, 0, len(provSettings))
+		for provider := range provSettings {
+			updatedProviders = append(updatedProviders, provider)
+		}
+		sort.Strings(updatedProviders)
+		h.logger.Info("Provider settings updated", "providers", updatedProviders)
+		if h.config != nil {
+			ApplyProviderSettingsFromDB(h.store, h.config, h.logger)
+		}
 		// Strip sensitive fields before returning to client
 		stripProviderSecrets(existing)
 		result["provider_settings"] = existing
@@ -10047,6 +10283,8 @@ func (h *Handler) LoggingHistory(w http.ResponseWriter, r *http.Request) {
 		h.loggingHistoryGemini(w, r)
 	case "cursor":
 		h.loggingHistoryCursor(w, r)
+	case "opencode":
+		h.loggingHistoryOpenCode(w, r)
 	default:
 		respondError(w, http.StatusBadRequest, fmt.Sprintf("unknown provider: %s", provider))
 	}

--- a/internal/web/opencode_handlers.go
+++ b/internal/web/opencode_handlers.go
@@ -1,0 +1,241 @@
+package web
+
+import (
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// currentOpenCode returns current OpenCode usage quotas.
+func (h *Handler) currentOpenCode(w http.ResponseWriter, r *http.Request) {
+	respondJSON(w, http.StatusOK, h.buildOpenCodeCurrent())
+}
+
+// buildOpenCodeCurrent builds current OpenCode response.
+func (h *Handler) buildOpenCodeCurrent() map[string]interface{} {
+	now := time.Now().UTC()
+	response := map[string]interface{}{
+		"capturedAt": now.Format(time.RFC3339),
+		"quotas":     []interface{}{},
+	}
+	if h.store == nil {
+		return response
+	}
+
+	latest, err := h.store.QueryLatestOpenCode()
+	if err != nil {
+		h.logger.Error("failed to query latest OpenCode snapshot", "error", err)
+		return response
+	}
+	if latest == nil {
+		return response
+	}
+
+	response["capturedAt"] = latest.CapturedAt.Format(time.RFC3339)
+	if latest.WorkspaceID != "" {
+		response["workspaceId"] = latest.WorkspaceID
+	}
+
+	var quotas []map[string]interface{}
+
+	// Rolling Usage
+	rollingUtil := normalizeOpenCodeUtilization(latest.RollingUsage.Utilization)
+	rollingUsagePercent := openCodeUsagePercent(latest.RollingUsage.Utilization)
+	quota := map[string]interface{}{
+		"quotaName":        "rolling_usage",
+		"utilization":      rollingUtil,
+		"usagePercent":     rollingUsagePercent,
+		"remainingPercent": max(0, 100-rollingUsagePercent),
+		"status":           openCodeUsageStatus(rollingUtil),
+	}
+	if latest.RollingUsage.ResetsAt != nil {
+		timeUntilReset := time.Until(*latest.RollingUsage.ResetsAt)
+		quota["resetTime"] = latest.RollingUsage.ResetsAt.Format(time.RFC3339)
+		quota["timeUntilReset"] = formatDuration(timeUntilReset)
+		quota["timeUntilResetSeconds"] = int64(timeUntilReset.Seconds())
+	}
+	if latest.RollingUsage.ResetInSec > 0 {
+		quota["timeUntilResetSeconds"] = int64(latest.RollingUsage.ResetInSec)
+	}
+	if h.opencodeTracker != nil {
+		if summary, err := h.opencodeTracker.UsageSummary("rolling"); err == nil && summary != nil {
+			quota["currentRate"] = summary.CurrentRate
+			quota["projectedUsage"] = normalizeOpenCodeUtilization(summary.ProjectedUtil)
+		}
+	}
+	quotas = append(quotas, quota)
+
+	// Weekly Usage
+	weeklyUtil := normalizeOpenCodeUtilization(latest.WeeklyUsage.Utilization)
+	weeklyUsagePercent := openCodeUsagePercent(latest.WeeklyUsage.Utilization)
+	quota = map[string]interface{}{
+		"quotaName":        "weekly_usage",
+		"utilization":      weeklyUtil,
+		"usagePercent":     weeklyUsagePercent,
+		"remainingPercent": max(0, 100-weeklyUsagePercent),
+		"status":           openCodeUsageStatus(weeklyUtil),
+	}
+	if latest.WeeklyUsage.ResetsAt != nil {
+		timeUntilReset := time.Until(*latest.WeeklyUsage.ResetsAt)
+		quota["resetTime"] = latest.WeeklyUsage.ResetsAt.Format(time.RFC3339)
+		quota["timeUntilReset"] = formatDuration(timeUntilReset)
+		quota["timeUntilResetSeconds"] = int64(timeUntilReset.Seconds())
+	}
+	if latest.WeeklyUsage.ResetInSec > 0 {
+		quota["timeUntilResetSeconds"] = int64(latest.WeeklyUsage.ResetInSec)
+	}
+	if h.opencodeTracker != nil {
+		if summary, err := h.opencodeTracker.UsageSummary("weekly"); err == nil && summary != nil {
+			quota["currentRate"] = summary.CurrentRate
+			quota["projectedUsage"] = normalizeOpenCodeUtilization(summary.ProjectedUtil)
+		}
+	}
+	quotas = append(quotas, quota)
+
+	// Monthly Usage (if available)
+	if latest.HasMonthlyUsage {
+		monthlyUtil := normalizeOpenCodeUtilization(latest.MonthlyUsage.Utilization)
+		monthlyUsagePercent := openCodeUsagePercent(latest.MonthlyUsage.Utilization)
+		quota = map[string]interface{}{
+			"quotaName":        "monthly_usage",
+			"utilization":      monthlyUtil,
+			"usagePercent":     monthlyUsagePercent,
+			"remainingPercent": max(0, 100-monthlyUsagePercent),
+			"status":           openCodeUsageStatus(monthlyUtil),
+		}
+		if latest.MonthlyUsage.ResetsAt != nil {
+			timeUntilReset := time.Until(*latest.MonthlyUsage.ResetsAt)
+			quota["resetTime"] = latest.MonthlyUsage.ResetsAt.Format(time.RFC3339)
+			quota["timeUntilReset"] = formatDuration(timeUntilReset)
+			quota["timeUntilResetSeconds"] = int64(timeUntilReset.Seconds())
+		}
+		if latest.MonthlyUsage.ResetInSec > 0 {
+			quota["timeUntilResetSeconds"] = int64(latest.MonthlyUsage.ResetInSec)
+		}
+		if h.opencodeTracker != nil {
+			if summary, err := h.opencodeTracker.UsageSummary("monthly"); err == nil && summary != nil {
+				quota["currentRate"] = summary.CurrentRate
+				quota["projectedUsage"] = normalizeOpenCodeUtilization(summary.ProjectedUtil)
+			}
+		}
+		quotas = append(quotas, quota)
+	}
+
+	response["quotas"] = quotas
+	return response
+}
+
+// historyOpenCode returns OpenCode usage history as a flat array.
+// Each entry has capturedAt and quota-keyed usage values.
+func (h *Handler) historyOpenCode(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		respondJSON(w, http.StatusOK, []interface{}{})
+		return
+	}
+
+	rangeStr := r.URL.Query().Get("range")
+	rangeDur, err := parseTimeRange(rangeStr)
+	if err != nil {
+		respondError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+
+	now := time.Now().UTC()
+	start := now.Add(-rangeDur)
+
+	snapshots, err := h.store.QueryOpenCodeRange(start, now)
+	if err != nil {
+		h.logger.Error("failed to query OpenCode history", "error", err)
+		respondError(w, http.StatusInternalServerError, "failed to query history")
+		return
+	}
+
+	var history []map[string]interface{}
+	for _, s := range snapshots {
+		entry := map[string]interface{}{
+			"capturedAt":    s.CapturedAt.Format(time.RFC3339),
+			"rolling_usage": openCodeUsagePercent(s.RollingUsage.Utilization),
+			"weekly_usage":  openCodeUsagePercent(s.WeeklyUsage.Utilization),
+		}
+		if s.HasMonthlyUsage {
+			entry["monthly_usage"] = openCodeUsagePercent(s.MonthlyUsage.Utilization)
+		}
+		history = append(history, entry)
+	}
+
+	respondJSON(w, http.StatusOK, history)
+}
+
+// cyclesOpenCode returns OpenCode reset cycle history.
+// Each cycle shows quota_name, cycle_start, cycle_end, peak_utilization, and total_delta.
+func (h *Handler) cyclesOpenCode(w http.ResponseWriter, r *http.Request) {
+	if h.store == nil {
+		respondJSON(w, http.StatusOK, map[string]interface{}{"cycles": []interface{}{}})
+		return
+	}
+
+	limitParam := r.URL.Query().Get("limit")
+	limit := 200
+	if limitParam != "" {
+		if v, err := strconv.Atoi(limitParam); err == nil && v > 0 && v < 200 {
+			limit = v
+		}
+	}
+
+	now := time.Now().UTC()
+	start := now.Add(-30 * 24 * time.Hour)
+	snapshots, err := h.store.QueryOpenCodeRange(start, now, limit)
+	if err != nil || len(snapshots) == 0 {
+		respondJSON(w, http.StatusOK, map[string]interface{}{"cycles": []interface{}{}})
+		return
+	}
+
+	// Build cycle data from snapshots for rolling_usage, weekly_usage, and monthly_usage
+	var results []map[string]interface{}
+	for i := len(snapshots) - 1; i >= 0; i-- {
+		snap := snapshots[i]
+		entry := map[string]interface{}{
+			"capturedAt":    snap.CapturedAt.Format(time.RFC3339),
+			"rolling_usage": openCodeUsagePercent(snap.RollingUsage.Utilization),
+			"weekly_usage":  openCodeUsagePercent(snap.WeeklyUsage.Utilization),
+		}
+		if snap.HasMonthlyUsage {
+			entry["monthly_usage"] = openCodeUsagePercent(snap.MonthlyUsage.Utilization)
+		} else {
+			entry["monthly_usage"] = 0.0
+		}
+		results = append(results, entry)
+	}
+
+	respondJSON(w, http.StatusOK, map[string]interface{}{"cycles": results})
+}
+
+// openCodeUsageStatus returns status string based on utilization.
+// Values must match the statusConfig keys used in the dashboard JS/CSS.
+func openCodeUsageStatus(utilization float64) string {
+	normalized := normalizeOpenCodeUtilization(utilization)
+	if normalized >= 0.9 {
+		return "critical"
+	}
+	if normalized >= 0.75 {
+		return "warning"
+	}
+	return "healthy"
+}
+
+func openCodeUsagePercent(utilization float64) float64 {
+	return normalizeOpenCodeUtilization(utilization) * 100
+}
+
+func normalizeOpenCodeUtilization(utilization float64) float64 {
+	switch {
+	case utilization < 0:
+		return 0
+	case utilization > 100:
+		return 1
+	case utilization > 1:
+		return utilization / 100
+	default:
+		return utilization
+	}
+}

--- a/internal/web/opencode_handlers_test.go
+++ b/internal/web/opencode_handlers_test.go
@@ -1,0 +1,317 @@
+package web
+
+import (
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/onllm-dev/onwatch/v2/internal/api"
+	"github.com/onllm-dev/onwatch/v2/internal/store"
+)
+
+func TestOpenCodeUsageStatus_NormalizesPercentInput(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name        string
+		utilization float64
+		expected    string
+	}{
+		{name: "healthy_percent_scale", utilization: 18, expected: "healthy"},
+		{name: "warning_percent_scale", utilization: 82, expected: "warning"},
+		{name: "critical_percent_scale", utilization: 95, expected: "critical"},
+		{name: "healthy_fraction_scale", utilization: 0.18, expected: "healthy"},
+		{name: "warning_fraction_scale", utilization: 0.82, expected: "warning"},
+		{name: "critical_fraction_scale", utilization: 1.0, expected: "critical"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := openCodeUsageStatus(tc.utilization); got != tc.expected {
+				t.Fatalf("openCodeUsageStatus(%v) = %q, want %q", tc.utilization, got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestBuildOpenCodeCurrent_NormalizesLegacyPercentSnapshot(t *testing.T) {
+	t.Parallel()
+
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	now := time.Now().UTC()
+	resetAt := now.Add(2 * time.Hour)
+	_, err = s.InsertOpenCodeSnapshot(&api.OpenCodeSnapshot{
+		CapturedAt:      now,
+		WorkspaceID:     "wrk_test",
+		HasMonthlyUsage: true,
+		RollingUsage: api.OpenCodeQuota{
+			Name:        "rolling",
+			Utilization: 18,
+			ResetsAt:    &resetAt,
+			ResetInSec:  int((2 * time.Hour).Seconds()),
+		},
+		WeeklyUsage: api.OpenCodeQuota{
+			Name:        "weekly",
+			Utilization: 82,
+			ResetsAt:    &resetAt,
+			ResetInSec:  int((2 * time.Hour).Seconds()),
+		},
+		MonthlyUsage: api.OpenCodeQuota{
+			Name:        "monthly",
+			Utilization: 5,
+			ResetsAt:    &resetAt,
+			ResetInSec:  int((2 * time.Hour).Seconds()),
+		},
+	})
+	if err != nil {
+		t.Fatalf("InsertOpenCodeSnapshot: %v", err)
+	}
+
+	h := NewHandler(s, nil, nil, nil, createTestConfigWithSynthetic())
+	resp := h.buildOpenCodeCurrent()
+
+	quotaList, ok := resp["quotas"].([]map[string]interface{})
+	if !ok {
+		t.Fatalf("expected quotas []map[string]interface{}, got %T", resp["quotas"])
+	}
+	if len(quotaList) != 3 {
+		t.Fatalf("expected 3 quotas, got %d", len(quotaList))
+	}
+
+	byName := map[string]map[string]interface{}{}
+	for _, q := range quotaList {
+		name, _ := q["quotaName"].(string)
+		byName[name] = q
+	}
+
+	rolling := byName["rolling_usage"]
+	if rolling == nil {
+		t.Fatal("missing rolling_usage quota")
+	}
+	assertOpenCodeFieldClose(t, rolling["usagePercent"], 18)
+	assertOpenCodeFieldClose(t, rolling["remainingPercent"], 82)
+	if status, _ := rolling["status"].(string); status != "healthy" {
+		t.Fatalf("expected rolling status healthy, got %q", status)
+	}
+
+	weekly := byName["weekly_usage"]
+	if weekly == nil {
+		t.Fatal("missing weekly_usage quota")
+	}
+	assertOpenCodeFieldClose(t, weekly["usagePercent"], 82)
+	if status, _ := weekly["status"].(string); status != "warning" {
+		t.Fatalf("expected weekly status warning, got %q", status)
+	}
+}
+
+func TestApplyProviderSettingsFromDB_OpenCodeCookie(t *testing.T) {
+	t.Parallel()
+
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	if err := s.SetSetting("provider_settings", `{"opencode":{"cookie":"raw_cookie_value"}}`); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+
+	cfg := createTestConfigWithSynthetic()
+	ApplyProviderSettingsFromDB(s, cfg, nil)
+
+	if got, want := cfg.OpenCodeCookie, "auth=raw_cookie_value"; got != want {
+		t.Fatalf("cfg.OpenCodeCookie = %q, want %q", got, want)
+	}
+	if cfg.OpenCodeAutoCookie {
+		t.Fatal("expected OpenCodeAutoCookie to be false after applying provider_settings")
+	}
+}
+
+func TestStripProviderSecrets_MasksCookie(t *testing.T) {
+	t.Parallel()
+
+	providers := map[string]interface{}{
+		"opencode": map[string]interface{}{
+			"cookie": "auth=secret_cookie",
+		},
+	}
+
+	stripProviderSecrets(providers)
+
+	opencode, ok := providers["opencode"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected opencode settings map, got %T", providers["opencode"])
+	}
+
+	if got, _ := opencode["cookie"].(string); got != "" {
+		t.Fatalf("expected masked cookie value, got %q", got)
+	}
+	if set, _ := opencode["cookie_set"].(bool); !set {
+		t.Fatalf("expected cookie_set=true, got %v", opencode["cookie_set"])
+	}
+}
+
+func assertOpenCodeFieldClose(t *testing.T, value interface{}, want float64) {
+	t.Helper()
+	got, ok := value.(float64)
+	if !ok {
+		t.Fatalf("expected float64 value, got %T", value)
+	}
+	if math.Abs(got-want) > 1e-9 {
+		t.Fatalf("expected %.4f, got %.4f", want, got)
+	}
+}
+
+func TestHistoryBoth_IncludesOpenCodeSeries(t *testing.T) {
+	t.Parallel()
+
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	now := time.Now().UTC()
+	resetAt := now.Add(2 * time.Hour)
+	_, err = s.InsertOpenCodeSnapshot(&api.OpenCodeSnapshot{
+		CapturedAt:      now.Add(-10 * time.Minute),
+		WorkspaceID:     "wrk_test",
+		HasMonthlyUsage: true,
+		RollingUsage: api.OpenCodeQuota{
+			Name:        "rolling",
+			Utilization: 0.2,
+			ResetsAt:    &resetAt,
+			ResetInSec:  int((2 * time.Hour).Seconds()),
+		},
+		WeeklyUsage: api.OpenCodeQuota{
+			Name:        "weekly",
+			Utilization: 0.5,
+			ResetsAt:    &resetAt,
+			ResetInSec:  int((2 * time.Hour).Seconds()),
+		},
+		MonthlyUsage: api.OpenCodeQuota{
+			Name:        "monthly",
+			Utilization: 0.8,
+			ResetsAt:    &resetAt,
+			ResetInSec:  int((2 * time.Hour).Seconds()),
+		},
+	})
+	if err != nil {
+		t.Fatalf("InsertOpenCodeSnapshot: %v", err)
+	}
+
+	cfg := createTestConfigWithSynthetic()
+	cfg.OpenCodeCookie = "test_cookie"
+	h := NewHandler(s, nil, nil, nil, cfg)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/history?provider=both&range=1h", nil)
+	rr := httptest.NewRecorder()
+	h.History(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+
+	opencode, ok := resp["opencode"].([]interface{})
+	if !ok {
+		t.Fatalf("expected opencode history array, got %T", resp["opencode"])
+	}
+	if len(opencode) == 0 {
+		t.Fatal("expected at least one opencode history point")
+	}
+
+	first, ok := opencode[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected opencode history row object, got %T", opencode[0])
+	}
+	assertOpenCodeFieldClose(t, first["rolling_usage"], 20)
+	assertOpenCodeFieldClose(t, first["weekly_usage"], 50)
+	assertOpenCodeFieldClose(t, first["monthly_usage"], 80)
+}
+
+func TestLoggingHistoryOpenCode_NormalizesLegacyPercentSnapshot(t *testing.T) {
+	t.Parallel()
+
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	now := time.Now().UTC()
+	resetAt := now.Add(90 * time.Minute)
+	_, err = s.InsertOpenCodeSnapshot(&api.OpenCodeSnapshot{
+		CapturedAt:      now.Add(-5 * time.Minute),
+		WorkspaceID:     "wrk_legacy",
+		HasMonthlyUsage: true,
+		RollingUsage: api.OpenCodeQuota{
+			Name:        "rolling",
+			Utilization: 18,
+			ResetsAt:    &resetAt,
+		},
+		WeeklyUsage: api.OpenCodeQuota{
+			Name:        "weekly",
+			Utilization: 82,
+			ResetsAt:    &resetAt,
+		},
+		MonthlyUsage: api.OpenCodeQuota{
+			Name:        "monthly",
+			Utilization: 5,
+			ResetsAt:    &resetAt,
+		},
+	})
+	if err != nil {
+		t.Fatalf("InsertOpenCodeSnapshot: %v", err)
+	}
+
+	h := NewHandler(s, nil, nil, nil, createTestConfigWithSynthetic())
+	req := httptest.NewRequest(http.MethodGet, "/api/logging-history?provider=opencode&range=1", nil)
+	rr := httptest.NewRecorder()
+	h.LoggingHistory(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+
+	logs, ok := resp["logs"].([]interface{})
+	if !ok || len(logs) == 0 {
+		t.Fatalf("expected non-empty logs, got %#v", resp["logs"])
+	}
+
+	firstLog, ok := logs[0].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected log object, got %T", logs[0])
+	}
+	quotaValues, ok := firstLog["quotaValues"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected quotaValues object, got %T", firstLog["quotaValues"])
+	}
+
+	rolling, ok := quotaValues["rolling_usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("expected rolling_usage object, got %T", quotaValues["rolling_usage"])
+	}
+	assertOpenCodeFieldClose(t, rolling["usagePercent"], 18)
+	assertOpenCodeFieldClose(t, rolling["utilization"], 0.18)
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -58,6 +58,7 @@ func NewServer(port int, handler *Handler, logger *slog.Logger, username, passwo
 	mux.HandleFunc(p("/api/providers/status"), handler.ProvidersStatus)
 	mux.HandleFunc(p("/api/providers/toggle"), handler.ToggleProvider)
 	mux.HandleFunc(p("/api/providers/reload"), handler.ReloadProviders)
+	mux.HandleFunc(p("/api/test-provider"), handler.TestProvider)
 	mux.HandleFunc(p("/api/current"), handler.Current)
 	mux.HandleFunc(p("/api/history"), handler.History)
 	mux.HandleFunc(p("/api/cycles"), handler.Cycles)

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -838,11 +838,13 @@ function codexVisibleQuotaNames(planType) {
 const anthropicQuotaOrder = ['five_hour', 'seven_day', 'seven_day_sonnet', 'monthly_limit', 'extra_usage'];
 const codexQuotaOrder = ['five_hour', 'seven_day', 'code_review'];
 const cursorQuotaOrder = ['total_usage', 'auto_usage', 'api_usage', 'credits', 'on_demand'];
+const opencodeQuotaOrder = ['rolling_usage', 'weekly_usage', 'monthly_usage'];
 
 function quotaOrderForProvider(provider) {
   if (provider === 'anthropic') return anthropicQuotaOrder;
   if (provider === 'codex') return codexQuotaOrder;
   if (provider === 'cursor') return cursorQuotaOrder;
+  if (provider === 'opencode') return opencodeQuotaOrder;
   return [];
 }
 
@@ -973,6 +975,12 @@ const cursorDisplayNames = {
   'on_demand': 'On-Demand',
 };
 
+const opencodeDisplayNames = {
+  'rolling_usage': 'Rolling Usage',
+  'weekly_usage': 'Weekly Usage',
+  'monthly_usage': 'Monthly Usage',
+};
+
 const geminiChartColorMap = {
   'pro': { border: '#4285F4', bg: 'rgba(66, 133, 244, 0.08)' },
   'flash': { border: '#34A853', bg: 'rgba(52, 168, 83, 0.08)' },
@@ -986,6 +994,54 @@ const cursorChartColorMap = {
   'credits': { border: '#10b981', bg: 'rgba(16, 185, 129, 0.08)' },
   'on_demand': { border: '#f59e0b', bg: 'rgba(245, 158, 11, 0.08)' },
 };
+
+const opencodeChartColorMap = {
+  'rolling_usage': { border: '#3b82f6', bg: 'rgba(59, 130, 246, 0.08)' },
+  'weekly_usage': { border: '#10b981', bg: 'rgba(16, 185, 129, 0.08)' },
+  'monthly_usage': { border: '#f59e0b', bg: 'rgba(245, 158, 11, 0.08)' },
+};
+
+function normalizeOpenCodeUsageValue(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  if (numeric < 0) return 0;
+  if (numeric > 1) return Math.min(1, numeric / 100);
+  return numeric;
+}
+
+function normalizeOpenCodeUsagePercent(value) {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return 0;
+  if (numeric < 0) return 0;
+  if (numeric < 1) return Math.min(100, numeric * 100);
+  if (numeric > 100) return 100;
+  return numeric;
+}
+
+function getOpenCodeStatus(percent) {
+  if (percent >= 90) return 'critical';
+  if (percent >= 75) return 'warning';
+  return 'healthy';
+}
+
+function getOpenCodeUsageMetrics(quota) {
+  let percent;
+  if (quota?.usagePercent != null) {
+    percent = normalizeOpenCodeUsagePercent(quota.usagePercent);
+  } else {
+    percent = normalizeOpenCodeUsageValue(quota?.utilization) * 100;
+  }
+  const ratio = percent / 100;
+  let remainingPercent = Number(quota?.remainingPercent);
+  if (!Number.isFinite(remainingPercent)) {
+    remainingPercent = 100 - percent;
+  } else if (remainingPercent <= 1 && remainingPercent >= 0) {
+    remainingPercent *= 100;
+  }
+  remainingPercent = Math.max(0, Math.min(100, remainingPercent));
+
+  return { ratio, percent, remainingPercent };
+}
 const cursorChartColorFallback = [
   { border: '#6366f1', bg: 'rgba(99, 102, 241, 0.08)' },
   { border: '#8b5cf6', bg: 'rgba(139, 92, 246, 0.08)' },
@@ -1050,6 +1106,11 @@ const renewalCategories = {
     { label: 'API Usage', groupBy: 'api_usage' },
     { label: 'Credits', groupBy: 'credits' },
     { label: 'On-Demand', groupBy: 'on_demand' }
+  ],
+  opencode: [
+    { label: 'Rolling Usage', groupBy: 'rolling_usage' },
+    { label: 'Weekly Usage', groupBy: 'weekly_usage' },
+    { label: 'Monthly Usage', groupBy: 'monthly_usage' }
   ]
 };
 
@@ -1072,6 +1133,9 @@ const overviewQuotaDisplayNames = {
   antigravity_gemini_pro: 'Gemini Pro Quota',
   antigravity_gemini_flash: 'Gemini Flash Quota',
   credits: 'Credits',
+  rolling_usage: 'Rolling Usage',
+  weekly_usage: 'Weekly Usage',
+  monthly_usage: 'Monthly Usage',
   total_usage: 'Total Usage',
   auto_usage: 'Auto + Composer',
   api_usage: 'API Usage',
@@ -1090,6 +1154,11 @@ const providerQuotaDisplayOverrides = {
     'pro': 'Gemini Pro',
     'flash': 'Gemini Flash',
     'flash_lite': 'Gemini Flash Lite',
+  },
+  opencode: {
+    'rolling_usage': 'Rolling Usage',
+    'weekly_usage': 'Weekly Usage',
+    'monthly_usage': 'Monthly Usage',
   }
 };
 
@@ -2095,6 +2164,60 @@ function renderGeminiQuotaCards(quotas, containerId) {
       if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); handler(); }
     });
   });
+}
+
+// ── OpenCode Quota Cards ──
+
+function renderOpenCodeQuotaCards(quotas, containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+
+  if (!quotas || quotas.length === 0) {
+    container.innerHTML = '<p class="empty-state">No OpenCode GO quota data available.</p>';
+    return;
+  }
+
+  container.innerHTML = quotas.map((q, i) => {
+    const displayName = opencodeDisplayNames[q.quotaName] || q.quotaName;
+    const usage = getOpenCodeUsageMetrics(q);
+    const usagePct = usage.percent.toFixed(1);
+    const status = getOpenCodeStatus(usage.percent);
+    const statusCfg = statusConfig[status] || statusConfig.healthy;
+    const countdownId = `countdown-opencode-${q.quotaName}`;
+    const progressId = `progress-opencode-${q.quotaName}`;
+    const percentId = `percent-opencode-${q.quotaName}`;
+    const fractionId = `fraction-opencode-${q.quotaName}`;
+    const statusId = `status-opencode-${q.quotaName}`;
+    const resetId = `reset-opencode-${q.quotaName}`;
+
+    const fractionText = `${usage.remainingPercent.toFixed(1)}% remaining`;
+
+    return `<article class="quota-card opencode-card" data-quota="${q.quotaName}" data-provider="opencode" role="button" tabindex="0" aria-label="View ${displayName} details" style="animation-delay: ${i * 60}ms">
+      <header class="card-header">
+        <h2 class="quota-title">
+          <svg class="quota-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg>
+          ${displayName}
+        </h2>
+        <span class="countdown" id="${countdownId}">${q.timeUntilResetSeconds > 0 ? formatDuration(q.timeUntilResetSeconds) : '--:--'}</span>
+      </header>
+      <div class="progress-stats">
+        <span class="usage-percent" id="${percentId}">${usagePct}%</span>
+        <span class="usage-fraction" id="${fractionId}">${fractionText}</span>
+      </div>
+      <div class="progress-wrapper">
+        <div class="progress-bar" role="progressbar" aria-valuenow="${Math.round(usage.percent)}" aria-valuemin="0" aria-valuemax="100">
+          <div class="progress-fill" id="${progressId}" style="width: ${usagePct}%" data-status="${status}"></div>
+        </div>
+      </div>
+      <footer class="card-footer">
+        <span class="status-badge" id="${statusId}" data-status="${status}">
+          <svg class="status-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="${statusCfg.icon}"/></svg>
+          ${statusCfg.label}
+        </span>
+        <span class="reset-time" id="${resetId}">${q.resetTime ? 'Resets: ' + formatDateTime(q.resetTime) : ''}</span>
+      </footer>
+    </article>`;
+  }).join('');
 }
 
 function renderCursorQuotaCards(quotas, containerId) {
@@ -3379,7 +3502,11 @@ async function fetchCurrent() {
         if (data.quotas) {
           renderCursorQuotaCards(data.quotas || [], 'quota-grid-cursor');
         }
-      } else if (provider === 'openrouter') {
+      } else if (provider === 'opencode') {
+        if (data.quotas) {
+          renderOpenCodeQuotaCards(data.quotas, 'quota-grid-opencode');
+        }
+      }else if (provider === 'openrouter') {
         if (data.credits) {
           const container = document.getElementById('quota-grid-openrouter');
           if (container && container.children.length === 0) {
@@ -4086,6 +4213,8 @@ function initChart() {
     defaultDatasets = []; // Cursor datasets are dynamic - populated when history data arrives
   } else if (provider === 'openrouter') {
     defaultDatasets = []; // OpenRouter datasets are dynamic - populated when history data arrives
+  } else if (provider === 'opencode') {
+    defaultDatasets = []; // OpenCode datasets are dynamic - populated when history data arrives
   } else if (provider === 'zai') {
     defaultDatasets = [
       { label: 'Tokens Limit', data: [], borderColor: getComputedStyle(document.documentElement).getPropertyValue('--chart-subscription').trim() || '#0D9488', backgroundColor: 'rgba(13, 148, 136, 0.06)', fill: true, tension: 0.4, borderWidth: 2, pointRadius: 0, pointHoverRadius: 4, hidden: State.hiddenQuotas.has('tokensLimit') },
@@ -4526,6 +4655,42 @@ async function fetchHistory(range) {
       return;
     }
 
+    if (provider === 'opencode') {
+      const quotaKeys = new Set();
+      historyRows.forEach(d => {
+        Object.keys(d).forEach(k => { if (k !== 'capturedAt') quotaKeys.add(k); });
+      });
+      const sortedKeys = sortQuotaKeysForProvider(quotaKeys, 'opencode');
+      let fallbackIdx = 0;
+      const datasets = [];
+      sortedKeys.forEach((key) => {
+        const color = opencodeChartColorMap[key] || cursorChartColorFallback[fallbackIdx++ % cursorChartColorFallback.length];
+        const rawData = historyRows.map(d => ({ x: new Date(d.capturedAt), y: d[key] || 0 }));
+        const { data, gapSegments, pointRadii } = processDataWithGaps(rawData, range);
+        const mainDataset = {
+          label: opencodeDisplayNames[key] || key,
+          data: data,
+          borderColor: color.border,
+          backgroundColor: color.bg,
+          fill: true,
+          tension: 0.4,
+          borderWidth: 2,
+          pointRadius: pointRadii,
+          pointHoverRadius: 4,
+          hidden: State.hiddenQuotas.has(key),
+          spanGaps: true,
+          segment: getSegmentStyle(gapSegments, color.border)
+        };
+        datasets.push(mainDataset);
+      });
+      State.chart.data.datasets = datasets;
+      updateTimeScale(State.chart, range);
+      State.chartYMax = computeYMax(State.chart.data.datasets, State.chart);
+      State.chart.options.scales.y.max = State.chartYMax;
+      State.chart.update();
+      return;
+    }
+
     if (provider === 'openrouter') {
       const quotaKeys = new Set();
       historyRows.forEach(d => {
@@ -4656,6 +4821,7 @@ const bothProviderNames = {
   minimax: 'MiniMax',
   gemini: 'Gemini',
   cursor: 'Cursor',
+  opencode: 'OpenCode GO',
   'api-integrations': 'API Integrations',
 };
 
@@ -4769,6 +4935,26 @@ function normalizeBothQuotas(provider, payload) {
         };
       })
       .filter(Boolean);
+  }
+
+  if (provider === 'opencode') {
+    if (!Array.isArray(payload.quotas)) return [];
+    return payload.quotas.map((quota) => {
+      const displayName = opencodeDisplayNames[quota.quotaName] || quota.quotaName || 'QUOTA';
+      const usage = getOpenCodeUsageMetrics(quota);
+      return {
+        name: quota.quotaName,
+        displayName: displayName,
+        cardPercent: usage.percent,
+        cardLabel: 'Utilization',
+        status: getOpenCodeStatus(usage.percent),
+        timeUntilResetSeconds: quota.timeUntilResetSeconds || 0,
+        resetsAt: quota.resetTime || quota.resetsAt || '',
+        utilization: usage.ratio,
+        usagePercent: usage.percent,
+        remainingPercent: usage.remainingPercent,
+      };
+    });
   }
 
   if (!Array.isArray(payload.quotas)) return [];
@@ -5496,6 +5682,14 @@ function buildProviderCardDatasets(provider, rows, range) {
   if (provider === 'gemini') {
     return buildDynamicDatasetsForRows(rows, range, geminiDisplayNames, geminiChartColorMap, geminiChartColorFallback, 'gemini');
   }
+  if (provider === 'opencode') {
+    const fallback = [
+      { border: '#3b82f6', bg: 'rgba(59, 130, 246, 0.08)' },
+      { border: '#10b981', bg: 'rgba(16, 185, 129, 0.08)' },
+      { border: '#f59e0b', bg: 'rgba(245, 158, 11, 0.08)' },
+    ];
+    return buildDynamicDatasetsForRows(rows, range, opencodeDisplayNames, opencodeChartColorMap, fallback, 'opencode');
+  }
   if (provider === 'cursor') {
     const normalizedRows = rows.map((row) => {
       if (!Array.isArray(row.quotas)) return row;
@@ -5672,6 +5866,9 @@ function updateBothCharts(data, range = '6h') {
   if (activeProviders.has('cursor') && Array.isArray(data.cursor) && data.cursor.length > 0) {
     slots.push({ id: 'cursor', label: 'Cursor', provider: 'cursor', rows: data.cursor });
   }
+  if (activeProviders.has('opencode') && Array.isArray(data.opencode) && data.opencode.length > 0) {
+    slots.push({ id: 'opencode', label: 'OpenCode GO', provider: 'opencode', rows: data.opencode });
+  }
   if (activeProviders.has('codex')) {
     if (Array.isArray(data.codexAccounts) && data.codexAccounts.length > 0) {
       data.codexAccounts.forEach((account, idx) => {
@@ -5787,6 +5984,13 @@ function updateBothCharts(data, range = '6h') {
       datasets = createDynamicDatasets(slot.rows, minimaxDisplayNames, minimaxChartColorMap, minimaxChartColorFallback, 'minimax');
     } else if (slot.provider === 'gemini') {
       datasets = createDynamicDatasets(slot.rows, geminiDisplayNames, geminiChartColorMap, geminiChartColorFallback, 'gemini');
+    } else if (slot.provider === 'opencode') {
+      const opencodeFallback = [
+        { border: '#3b82f6', bg: 'rgba(59, 130, 246, 0.08)' },
+        { border: '#10b981', bg: 'rgba(16, 185, 129, 0.08)' },
+        { border: '#f59e0b', bg: 'rgba(245, 158, 11, 0.08)' },
+      ];
+      datasets = createDynamicDatasets(slot.rows, opencodeDisplayNames, opencodeChartColorMap, opencodeFallback, 'opencode');
     } else if (slot.provider === 'cursor') {
       const normalizedRows = slot.rows.map((row) => {
         if (!Array.isArray(row.quotas)) return row;
@@ -8846,6 +9050,13 @@ const providerSettingsConfig = {
     desc: 'Gemini is auto-detected from your local credentials. Use the telemetry toggle to enable or disable tracking.',
     fields: [],
   },
+  opencode: {
+    title: 'OpenCode GO',
+    desc: 'Open OpenCode GO (opencode.ai) while logged in, then copy the auth cookie value from DevTools > Application > Cookies > https://opencode.ai. Paste it below to save it in onWatch settings.',
+    fields: [
+      { id: 'cookie', label: 'auth Cookie Value', type: 'password', placeholder: 'Paste auth cookie value', hint: 'Path: DevTools > Application > Cookies > https://opencode.ai - copy the value from auth.', sensitive: true },
+    ],
+  },
 };
 
 async function openProviderSettingsModal(providerKey) {
@@ -8866,9 +9077,18 @@ async function openProviderSettingsModal(providerKey) {
   // Build fields HTML (shared for non-Codex providers)
   let buildFieldsHTML = () => {
     if (config.fields.length === 0) {
-      return `<p style="color:var(--text-secondary);font-size:14px;margin:0">${config.desc}</p>`;
+      let html = `<p style="color:var(--text-secondary);font-size:14px;margin:0">${config.desc}</p>`;
+      if (config.showTestButton) {
+        html += `<button id="test-provider-btn" class="btn" style="margin-top:16px;padding:8px 16px;font-size:13px;background:var(--accent);color:white;border:none;border-radius:4px;cursor:pointer;">Test Connection</button>`;
+        html += `<div id="test-provider-result" style="margin-top:12px;padding:10px;background:var(--bg-secondary);border-radius:4px;font-size:12px;color:var(--text-secondary);display:none;"></div>`;
+      }
+      return html;
     }
     let html = `<p style="color:var(--text-secondary);font-size:13px;margin:0 0 20px">${config.desc}</p>`;
+    if (config.showTestButton) {
+      html += `<button id="test-provider-btn" class="btn" style="margin-top:16px;padding:8px 16px;font-size:13px;background:var(--accent);color:white;border:none;border-radius:4px;cursor:pointer;">Test Connection</button>`;
+      html += `<div id="test-provider-result" style="margin-top:12px;padding:10px;background:var(--bg-secondary);border-radius:4px;font-size:12px;color:var(--text-secondary);display:none;"></div>`;
+    }
     html += '<div class="settings-fields">';
     config.fields.forEach(f => {
       html += '<div class="settings-field">';
@@ -9120,6 +9340,39 @@ async function openProviderSettingsModal(providerKey) {
     bodyEl.innerHTML = buildFieldsHTML();
   }
 
+  // Attach test button handler if present
+  const testBtn = document.getElementById('test-provider-btn');
+  if (testBtn && config.showTestButton) {
+    testBtn.addEventListener('click', async () => {
+      const resultDiv = document.getElementById('test-provider-result');
+      if (!resultDiv) return;
+      
+      testBtn.disabled = true;
+      testBtn.textContent = 'Testing...';
+      resultDiv.style.display = 'block';
+      resultDiv.textContent = 'Testing connection...';
+      
+      try {
+        const res = await authFetch(`${API_BASE}/api/test-provider?provider=${providerKey}`);
+        const data = await res.json();
+        
+        if (res.ok) {
+          resultDiv.style.color = 'var(--md-success,#2e7d32)';
+          resultDiv.textContent = data.message || 'Connection test successful';
+        } else {
+          resultDiv.style.color = 'var(--md-error,#b3261e)';
+          resultDiv.textContent = data.error || 'Connection test failed';
+        }
+      } catch (err) {
+        resultDiv.style.color = 'var(--md-error,#b3261e)';
+        resultDiv.textContent = 'Test failed: ' + err.message;
+      } finally {
+        testBtn.disabled = false;
+        testBtn.textContent = 'Test Connection';
+      }
+    });
+  }
+
   // Store which provider is being edited
   modal.dataset.providerKey = providerKey;
   modal.hidden = false;
@@ -9150,7 +9403,8 @@ async function saveProviderSettings() {
 
     if (f.type === 'password' && f.sensitive) {
       // Only include if user typed a new value
-      if (el.value) provData[f.id] = el.value;
+      const value = el.value.trim();
+      if (value) provData[f.id] = value;
     } else if (f.type === 'number') {
       provData[f.id] = parseInt(el.value, 10) || f.default || 0;
     } else {

--- a/internal/web/templates/dashboard.html
+++ b/internal/web/templates/dashboard.html
@@ -2,38 +2,56 @@
 <div class="app" data-poll-interval="{{.PollIntervalSec}}">
     <header class="app-header">
         <a href="#" class="header-brand" id="scroll-top" aria-label="Scroll to top">
-            <svg class="brand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                <path d="M12 2v20M2 12h20M4.93 4.93l14.14 14.14M19.07 4.93L4.93 19.07"/>
+            <svg class="brand-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                stroke-linecap="round" stroke-linejoin="round">
+                <path d="M12 2v20M2 12h20M4.93 4.93l14.14 14.14M19.07 4.93L4.93 19.07" />
             </svg>
             <span class="brand-text">onWatch</span>
         </a>
         {{if gt (len .Providers) 1}}
         <div class="provider-tabs" id="provider-tabs" role="tablist" aria-label="Select provider">
             {{range .Providers}}
-            <button class="provider-tab {{if eq . $.CurrentProvider}}active{{end}}"
-                    data-provider="{{.}}" role="tab" aria-selected="{{if eq . $.CurrentProvider}}true{{else}}false{{end}}">
-                {{if eq . "synthetic"}}Synthetic{{else if eq . "zai"}}Z.ai{{else if eq . "anthropic"}}Anthropic{{else if eq . "copilot"}}Copilot{{else if eq . "codex"}}Codex{{else if eq . "antigravity"}}Antigravity{{else if eq . "minimax"}}MiniMax{{else if eq . "gemini"}}Gemini{{else if eq . "cursor"}}Cursor{{else if eq . "api-integrations"}}API Integrations{{else if eq . "both"}}All{{else}}{{.}}{{end}}
+            <button class="provider-tab {{if eq . $.CurrentProvider}}active{{end}}" data-provider="{{.}}" role="tab"
+                aria-selected="{{if eq . $.CurrentProvider}}true{{else}}false{{end}}">
+                {{if eq . "synthetic"}}Synthetic{{else if eq . "zai"}}Z.ai{{else if eq . "anthropic"}}Anthropic{{else if
+                eq . "copilot"}}Copilot{{else if eq . "codex"}}Codex{{else if eq . "antigravity"}}Antigravity{{else if
+                eq . "minimax"}}MiniMax{{else if eq . "gemini"}}Gemini{{else if eq . "cursor"}}Cursor{{else if eq .
+                "opencode"}}OpenCode GO{{else if eq . "api-integrations"}}API Integrations{{else if eq .
+                "both"}}All{{else}}{{.}}{{end}}
             </button>
             {{end}}
         </div>
         {{end}}
         <div class="codex-profile-dropdown" id="codex-profile-dropdown" style="display: none;">
-            <button class="codex-profile-trigger" id="codex-profile-trigger" aria-haspopup="listbox" aria-expanded="false">
+            <button class="codex-profile-trigger" id="codex-profile-trigger" aria-haspopup="listbox"
+                aria-expanded="false">
                 <span class="codex-profile-label" id="codex-profile-label">Profile</span>
-                <svg class="codex-profile-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
+                <svg class="codex-profile-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                    stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M6 9l6 6 6-6" />
+                </svg>
             </button>
-            <ul class="codex-profile-menu" id="codex-profile-menu" role="listbox" aria-label="Select Codex profile"></ul>
+            <ul class="codex-profile-menu" id="codex-profile-menu" role="listbox" aria-label="Select Codex profile">
+            </ul>
         </div>
         <div class="codex-profile-dropdown" id="minimax-profile-dropdown" style="display: none;">
-            <button class="codex-profile-trigger" id="minimax-profile-trigger" aria-haspopup="listbox" aria-expanded="false">
+            <button class="codex-profile-trigger" id="minimax-profile-trigger" aria-haspopup="listbox"
+                aria-expanded="false">
                 <span class="codex-profile-label" id="minimax-profile-label">Account</span>
-                <svg class="codex-profile-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M6 9l6 6 6-6"/></svg>
+                <svg class="codex-profile-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                    stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <path d="M6 9l6 6 6-6" />
+                </svg>
             </button>
-            <ul class="codex-profile-menu" id="minimax-profile-menu" role="listbox" aria-label="Select MiniMax account"></ul>
+            <ul class="codex-profile-menu" id="minimax-profile-menu" role="listbox" aria-label="Select MiniMax account">
+            </ul>
         </div>
         <div class="header-actions">
             <button class="header-btn" id="refresh-btn" aria-label="Refresh data" title="Refresh now">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                    <path d="M3 3v5h5" />
+                </svg>
             </button>
             <div class="header-meta">
                 <span class="last-updated" id="last-updated">Last updated: --:--:--</span>
@@ -42,19 +60,23 @@
         </div>
         <!-- Notification Center -->
         <div class="notification-center" id="notification-center">
-            <button class="notification-bell" id="notification-bell" aria-label="Notifications" aria-expanded="false" aria-haspopup="true" title="Notifications">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/>
-                    <path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+            <button class="notification-bell" id="notification-bell" aria-label="Notifications" aria-expanded="false"
+                aria-haspopup="true" title="Notifications">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                    stroke-linejoin="round" aria-hidden="true">
+                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+                    <path d="M13.73 21a2 2 0 0 1-3.46 0" />
                 </svg>
-                <span class="notification-badge" id="notification-badge" style="display: none;" aria-live="polite">0</span>
+                <span class="notification-badge" id="notification-badge" style="display: none;"
+                    aria-live="polite">0</span>
             </button>
             <div class="notification-dropdown" id="notification-dropdown" role="menu" aria-label="Notifications">
                 <div class="notification-header">
                     <span class="notification-title">Notifications</span>
-                    <button class="notification-dismiss-all" id="dismiss-all-alerts" title="Dismiss all" aria-label="Clear all notifications">
+                    <button class="notification-dismiss-all" id="dismiss-all-alerts" title="Dismiss all"
+                        aria-label="Clear all notifications">
                         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M18 6L6 18M6 6l12 12"/>
+                            <path d="M18 6L6 18M6 6l12 12" />
                         </svg>
                         Clear all
                     </button>
@@ -66,23 +88,32 @@
         </div>
 
         <div class="header-controls">
-            <a href="{{.BasePath}}/settings" class="header-btn" id="settings-btn" aria-label="Settings" title="Settings">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <circle cx="12" cy="12" r="3"/>
-                    <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/>
+            <a href="{{.BasePath}}/settings" class="header-btn" id="settings-btn" aria-label="Settings"
+                title="Settings">
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                    stroke-linejoin="round">
+                    <circle cx="12" cy="12" r="3" />
+                    <path
+                        d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z" />
                 </svg>
             </a>
             <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
                 <svg class="icon-sun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <circle cx="12" cy="12" r="5"/>
-                    <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42"/>
+                    <circle cx="12" cy="12" r="5" />
+                    <path
+                        d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
                 </svg>
                 <svg class="icon-moon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
                 </svg>
             </button>
             <a href="{{.BasePath}}/logout" class="header-btn" id="logout-btn" aria-label="Logout" title="Logout">
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round"
+                    stroke-linejoin="round">
+                    <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
+                    <polyline points="16 17 21 12 16 7" />
+                    <line x1="21" y1="12" x2="9" y2="12" />
+                </svg>
             </a>
         </div>
     </header>
@@ -120,6 +151,9 @@
         {{else if eq .CurrentProvider "cursor"}}
         <!-- Cursor quota cards (dynamically populated by JS) -->
         <div class="quota-grid" id="quota-grid-cursor" data-provider="cursor"></div>
+        {{else if eq .CurrentProvider "opencode"}}
+        <!-- OpenCode quota cards (dynamically populated by JS) -->
+        <div class="quota-grid" id="quota-grid-opencode" data-provider="opencode"></div>
         {{else if eq .CurrentProvider "api-integrations"}}
         <div class="api-integrations-dashboard" id="api-integrations-dashboard" data-provider="api-integrations">
             <div class="quota-grid" id="api-integrations-grid"></div>
@@ -128,11 +162,12 @@
         <div class="quota-grid" id="quota-grid" data-provider="{{.CurrentProvider}}">
             {{if eq .CurrentProvider "zai"}}
             <!-- Z.ai quota cards -->
-            <article class="quota-card" data-quota="tokensLimit" role="button" tabindex="0" aria-label="View Tokens Limit details">
+            <article class="quota-card" data-quota="tokensLimit" role="button" tabindex="0"
+                aria-label="View Tokens Limit details">
                 <header class="card-header">
                     <h2 class="quota-title">
                         <svg class="quota-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/>
+                            <path d="M12 2L2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5" />
                         </svg>
                         Tokens Limit
                     </h2>
@@ -143,14 +178,15 @@
                     <span class="usage-fraction" id="fraction-tokensLimit">0 / 200M</span>
                 </div>
                 <div class="progress-wrapper">
-                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0"
+                        aria-valuemax="100">
                         <div class="progress-fill" id="progress-tokensLimit" style="width: 0%"></div>
                     </div>
                 </div>
                 <footer class="card-footer">
                     <span class="status-badge" id="status-tokensLimit" data-status="healthy">
                         <svg class="status-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M20 6L9 17l-5-5"/>
+                            <path d="M20 6L9 17l-5-5" />
                         </svg>
                         Healthy
                     </span>
@@ -158,12 +194,13 @@
                 </footer>
             </article>
 
-            <article class="quota-card" data-quota="timeLimit" role="button" tabindex="0" aria-label="View Time Limit details">
+            <article class="quota-card" data-quota="timeLimit" role="button" tabindex="0"
+                aria-label="View Time Limit details">
                 <header class="card-header">
                     <h2 class="quota-title">
                         <svg class="quota-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <circle cx="12" cy="12" r="10"/>
-                            <polyline points="12 6 12 12 16 14"/>
+                            <circle cx="12" cy="12" r="10" />
+                            <polyline points="12 6 12 12 16 14" />
                         </svg>
                         Time Limit
                     </h2>
@@ -174,14 +211,15 @@
                     <span class="usage-fraction" id="fraction-timeLimit">0 / 1,000</span>
                 </div>
                 <div class="progress-wrapper">
-                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0"
+                        aria-valuemax="100">
                         <div class="progress-fill" id="progress-timeLimit" style="width: 0%"></div>
                     </div>
                 </div>
                 <footer class="card-footer">
                     <span class="status-badge" id="status-timeLimit" data-status="healthy">
                         <svg class="status-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M20 6L9 17l-5-5"/>
+                            <path d="M20 6L9 17l-5-5" />
                         </svg>
                         Healthy
                     </span>
@@ -189,11 +227,13 @@
                 </footer>
             </article>
 
-            <article class="quota-card" data-quota="toolCalls" role="button" tabindex="0" aria-label="View Tool Calls details">
+            <article class="quota-card" data-quota="toolCalls" role="button" tabindex="0"
+                aria-label="View Tool Calls details">
                 <header class="card-header">
                     <h2 class="quota-title">
                         <svg class="quota-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+                            <path
+                                d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
                         </svg>
                         Tool Calls
                     </h2>
@@ -204,7 +244,8 @@
                     <span class="usage-fraction" id="fraction-toolCalls">0 / 0</span>
                 </div>
                 <div class="progress-wrapper">
-                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0"
+                        aria-valuemax="100">
                         <div class="progress-fill" id="progress-toolCalls" style="width: 0%"></div>
                     </div>
                 </div>
@@ -212,7 +253,7 @@
                 <footer class="card-footer">
                     <span class="status-badge" id="status-toolCalls" data-status="healthy">
                         <svg class="status-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M20 6L9 17l-5-5"/>
+                            <path d="M20 6L9 17l-5-5" />
                         </svg>
                         Healthy
                     </span>
@@ -221,12 +262,13 @@
             </article>
             {{else}}
             <!-- Synthetic quota cards -->
-            <article class="quota-card" data-quota="subscription" role="button" tabindex="0" aria-label="View Subscription Quota details">
+            <article class="quota-card" data-quota="subscription" role="button" tabindex="0"
+                aria-label="View Subscription Quota details">
                 <header class="card-header">
                     <h2 class="quota-title">
                         <svg class="quota-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <rect x="2" y="7" width="20" height="14" rx="2" ry="2"/>
-                            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16"/>
+                            <rect x="2" y="7" width="20" height="14" rx="2" ry="2" />
+                            <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
                         </svg>
                         Subscription
                     </h2>
@@ -237,14 +279,15 @@
                     <span class="usage-fraction" id="fraction-subscription">0 / 0</span>
                 </div>
                 <div class="progress-wrapper">
-                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0"
+                        aria-valuemax="100">
                         <div class="progress-fill" id="progress-subscription" style="width: 0%"></div>
                     </div>
                 </div>
                 <footer class="card-footer">
                     <span class="status-badge" id="status-subscription" data-status="healthy">
                         <svg class="status-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M20 6L9 17l-5-5"/>
+                            <path d="M20 6L9 17l-5-5" />
                         </svg>
                         Healthy
                     </span>
@@ -252,12 +295,13 @@
                 </footer>
             </article>
 
-            <article class="quota-card" data-quota="search" role="button" tabindex="0" aria-label="View Search Hourly details">
+            <article class="quota-card" data-quota="search" role="button" tabindex="0"
+                aria-label="View Search Hourly details">
                 <header class="card-header">
                     <h2 class="quota-title">
                         <svg class="quota-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <circle cx="11" cy="11" r="8"/>
-                            <path d="m21 21-4.35-4.35"/>
+                            <circle cx="11" cy="11" r="8" />
+                            <path d="m21 21-4.35-4.35" />
                         </svg>
                         Search (Hourly)
                     </h2>
@@ -268,14 +312,15 @@
                     <span class="usage-fraction" id="fraction-search">0 / 0</span>
                 </div>
                 <div class="progress-wrapper">
-                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0"
+                        aria-valuemax="100">
                         <div class="progress-fill" id="progress-search" style="width: 0%"></div>
                     </div>
                 </div>
                 <footer class="card-footer">
                     <span class="status-badge" id="status-search" data-status="healthy">
                         <svg class="status-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M20 6L9 17l-5-5"/>
+                            <path d="M20 6L9 17l-5-5" />
                         </svg>
                         Healthy
                     </span>
@@ -283,11 +328,13 @@
                 </footer>
             </article>
 
-            <article class="quota-card" data-quota="toolCalls" role="button" tabindex="0" aria-label="View Tool Call Discounts details">
+            <article class="quota-card" data-quota="toolCalls" role="button" tabindex="0"
+                aria-label="View Tool Call Discounts details">
                 <header class="card-header">
                     <h2 class="quota-title">
                         <svg class="quota-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+                            <path
+                                d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z" />
                         </svg>
                         Tool Calls
                     </h2>
@@ -298,14 +345,15 @@
                     <span class="usage-fraction" id="fraction-toolCalls">0 / 0</span>
                 </div>
                 <div class="progress-wrapper">
-                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                    <div class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0"
+                        aria-valuemax="100">
                         <div class="progress-fill" id="progress-toolCalls" style="width: 0%"></div>
                     </div>
                 </div>
                 <footer class="card-footer">
                     <span class="status-badge" id="status-toolCalls" data-status="healthy">
                         <svg class="status-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M20 6L9 17l-5-5"/>
+                            <path d="M20 6L9 17l-5-5" />
                         </svg>
                         Healthy
                     </span>
@@ -321,9 +369,10 @@
             <section class="insights-panel" id="api-integrations-all-time-insights-panel">
                 <header class="section-header">
                     <h3 class="section-title">
-                        <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <circle cx="12" cy="12" r="10"/>
-                            <path d="M12 16v-4M12 8h.01"/>
+                        <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2">
+                            <circle cx="12" cy="12" r="10" />
+                            <path d="M12 16v-4M12 8h.01" />
                         </svg>
                         All Time Statistics
                     </h3>
@@ -336,9 +385,10 @@
             <section class="insights-panel" id="api-integrations-recent-insights-panel">
                 <header class="section-header">
                     <h3 class="section-title">
-                        <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                            <path d="M3 12h18"/>
-                            <path d="M12 3v18"/>
+                        <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                            stroke-width="2">
+                            <path d="M3 12h18" />
+                            <path d="M12 3v18" />
                         </svg>
                         Recent Usage Insights
                     </h3>
@@ -353,8 +403,8 @@
             <header class="section-header">
                 <h3 class="section-title">
                     <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="12" r="10"/>
-                        <path d="M12 16v-4M12 8h.01"/>
+                        <circle cx="12" cy="12" r="10" />
+                        <path d="M12 16v-4M12 8h.01" />
                     </svg>
                     Usage Insights
                 </h3>
@@ -371,14 +421,15 @@
             <header class="section-header">
                 <h3 class="section-title">
                     <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M3 3v18h18"/>
-                        <path d="M18.7 8l-5.1 5.2-2.8-2.7L7 14.3"/>
+                        <path d="M3 3v18h18" />
+                        <path d="M18.7 8l-5.1 5.2-2.8-2.7L7 14.3" />
                     </svg>
                     {{if eq .CurrentProvider "api-integrations"}}API Integration Usage{{else}}Usage Graphs{{end}}
                 </h3>
                 <div class="chart-controls">
                     {{if eq .CurrentProvider "api-integrations"}}
-                    <select class="page-size-select" id="api-integrations-metric-select" aria-label="API integrations chart metric">
+                    <select class="page-size-select" id="api-integrations-metric-select"
+                        aria-label="API integrations chart metric">
                         <option value="tokenPerCall">Tokens per Request</option>
                         <option value="requestCount">Requests</option>
                         <option value="accumulatedTokens">Accumulated Token Use</option>
@@ -405,7 +456,7 @@
             <header class="section-header">
                 <h3 class="section-title">
                     <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M12 2v20M2 12h20"/>
+                        <path d="M12 2v20M2 12h20" />
                     </svg>
                     Ingest Health
                 </h3>
@@ -424,7 +475,9 @@
                         </tr>
                     </thead>
                     <tbody id="api-integrations-health-tbody">
-                        <tr><td colspan="3" class="empty-state">No API integration ingest state yet.</td></tr>
+                        <tr>
+                            <td colspan="3" class="empty-state">No API integration ingest state yet.</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
@@ -434,8 +487,8 @@
             <header class="section-header">
                 <h3 class="section-title">
                     <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20"/>
-                        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z"/>
+                        <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+                        <path d="M6.5 2H20v20H6.5A2.5 2.5 0 0 1 4 19.5v-15A2.5 2.5 0 0 1 6.5 2z" />
                     </svg>
                     Setup Guide
                 </h3>
@@ -445,10 +498,15 @@
                     <article class="insight-card severity-info expanded">
                         <div class="insight-card-header">
                             <span class="insight-card-title">How Custom API Integrations Work</span>
-                            <span class="insight-card-values"><span class="insight-card-metric">JSONL + Tail</span></span>
+                            <span class="insight-card-values"><span class="insight-card-metric">JSONL +
+                                    Tail</span></span>
                         </div>
-                        <div class="insight-card-detail" style="max-height:none;opacity:1;margin-top:8px;padding-top:8px;">
-                            <div class="insight-card-desc">Your script makes a normal provider API call, extracts usage from the response, and appends one normalized JSON line into <code>~/.onwatch/api-integrations/</code>.<br> onWatch tails those files and stores the telemetry in SQLite.</div>
+                        <div class="insight-card-detail"
+                            style="max-height:none;opacity:1;margin-top:8px;padding-top:8px;">
+                            <div class="insight-card-desc">Your script makes a normal provider API call, extracts usage
+                                from the response, and appends one normalized JSON line into
+                                <code>~/.onwatch/api-integrations/</code>.<br> onWatch tails those files and stores the
+                                telemetry in SQLite.</div>
                         </div>
                     </article>
                     <article class="insight-card severity-info expanded">
@@ -456,8 +514,11 @@
                             <span class="insight-card-title">Quick Start</span>
                             <span class="insight-card-values"><span class="insight-card-metric">4 Steps</span></span>
                         </div>
-                        <div class="insight-card-detail" style="max-height:none;opacity:1;margin-top:8px;padding-top:8px;">
-                            <div class="insight-card-desc">1. Add a wrapper function around your API call. <br> 2. Write events into <code>~/.onwatch/api-integrations/</code>.<br> 3. Keep onWatch running.<br> 4. Verify ingestion in the health panel and the chart above.</div>
+                        <div class="insight-card-detail"
+                            style="max-height:none;opacity:1;margin-top:8px;padding-top:8px;">
+                            <div class="insight-card-desc">1. Add a wrapper function around your API call. <br> 2. Write
+                                events into <code>~/.onwatch/api-integrations/</code>.<br> 3. Keep onWatch running.<br>
+                                4. Verify ingestion in the health panel and the chart above.</div>
                         </div>
                     </article>
                     <article class="insight-card severity-info expanded">
@@ -465,8 +526,11 @@
                             <span class="insight-card-title">Reference Paths</span>
                             <span class="insight-card-values"><span class="insight-card-metric">Docs</span></span>
                         </div>
-                        <div class="insight-card-detail" style="max-height:none;opacity:1;margin-top:8px;padding-top:8px;">
-                            <div class="insight-card-desc">Setup doc: <code>docs/API_INTEGRATIONS_SETUP.md</code>.<br> Wrapper found in: <code>examples/api_integrations/</code>.<br> Supported .py examples include:<br>Anthropic, OpenAI, Mistral, OpenRouter, and Gemini.</div>
+                        <div class="insight-card-detail"
+                            style="max-height:none;opacity:1;margin-top:8px;padding-top:8px;">
+                            <div class="insight-card-desc">Setup doc: <code>docs/API_INTEGRATIONS_SETUP.md</code>.<br>
+                                Wrapper found in: <code>examples/api_integrations/</code>.<br> Supported .py examples
+                                include:<br>Anthropic, OpenAI, Mistral, OpenRouter, and Gemini.</div>
                         </div>
                     </article>
                 </div>
@@ -479,9 +543,9 @@
             <header class="section-header">
                 <h3 class="section-title">
                     <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
-                        <circle cx="9" cy="7" r="4"/>
-                        <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75"/>
+                        <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+                        <circle cx="9" cy="7" r="4" />
+                        <path d="M23 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
                     </svg>
                     Session History
                 </h3>
@@ -498,39 +562,64 @@
                 <table class="data-table" id="sessions-table" data-provider="{{.CurrentProvider}}">
                     <thead>
                         <tr>
-                            {{if ne .CurrentProvider "minimax"}}<th data-sort-key="id" role="button" tabindex="0">Session <span class="sort-arrow"></span></th>{{end}}
-                            <th data-sort-key="start" role="button" tabindex="0">Started <span class="sort-arrow"></span></th>
-                            <th data-sort-key="end" role="button" tabindex="0">Ended <span class="sort-arrow"></span></th>
-                            <th data-sort-key="duration" role="button" tabindex="0">Duration <span class="sort-arrow"></span></th>
+                            {{if ne .CurrentProvider "minimax"}}<th data-sort-key="id" role="button" tabindex="0">
+                                Session <span class="sort-arrow"></span></th>{{end}}
+                            <th data-sort-key="start" role="button" tabindex="0">Started <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="end" role="button" tabindex="0">Ended <span class="sort-arrow"></span>
+                            </th>
+                            <th data-sort-key="duration" role="button" tabindex="0">Duration <span
+                                    class="sort-arrow"></span></th>
                             {{if eq .CurrentProvider "anthropic"}}
-                            <th data-sort-key="sub" role="button" tabindex="0" id="anth-session-col-0">5-Hour <span class="sort-arrow"></span></th>
-                            <th data-sort-key="search" role="button" tabindex="0" id="anth-session-col-1">Weekly <span class="sort-arrow"></span></th>
-                            <th data-sort-key="tool" role="button" tabindex="0" id="anth-session-col-2">Sonnet <span class="sort-arrow"></span></th>
+                            <th data-sort-key="sub" role="button" tabindex="0" id="anth-session-col-0">5-Hour <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="search" role="button" tabindex="0" id="anth-session-col-1">Weekly <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="tool" role="button" tabindex="0" id="anth-session-col-2">Sonnet <span
+                                    class="sort-arrow"></span></th>
                             {{else if eq .CurrentProvider "zai"}}
-                            <th data-sort-key="snapshots" role="button" tabindex="0">Snapshots <span class="sort-arrow"></span></th>
+                            <th data-sort-key="snapshots" role="button" tabindex="0">Snapshots <span
+                                    class="sort-arrow"></span></th>
                             {{else if eq .CurrentProvider "codex"}}
-                            <th data-sort-key="sub" role="button" tabindex="0" id="codex-session-col-0">5-Hour Limit <span class="sort-arrow"></span></th>
-                            <th data-sort-key="search" role="button" tabindex="0" id="codex-session-col-1">Weekly All-Model <span class="sort-arrow"></span></th>
+                            <th data-sort-key="sub" role="button" tabindex="0" id="codex-session-col-0">5-Hour Limit
+                                <span class="sort-arrow"></span></th>
+                            <th data-sort-key="search" role="button" tabindex="0" id="codex-session-col-1">Weekly
+                                All-Model <span class="sort-arrow"></span></th>
                             {{else if eq .CurrentProvider "minimax"}}
-                            <th data-sort-key="sub" role="button" tabindex="0">Peak Requests <span class="sort-arrow"></span></th>
-                            <th data-sort-key="search" role="button" tabindex="0">Requests Used <span class="sort-arrow"></span></th>
-                            <th data-sort-key="tool" role="button" tabindex="0">Snapshots <span class="sort-arrow"></span></th>
+                            <th data-sort-key="sub" role="button" tabindex="0">Peak Requests <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="search" role="button" tabindex="0">Requests Used <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="tool" role="button" tabindex="0">Snapshots <span
+                                    class="sort-arrow"></span></th>
                             {{else if eq .CurrentProvider "antigravity"}}
-                            <th data-sort-key="sub" role="button" tabindex="0">Claude + GPT Quota <span class="sort-arrow"></span></th>
-                            <th data-sort-key="search" role="button" tabindex="0">Gemini Pro Quota <span class="sort-arrow"></span></th>
-                            <th data-sort-key="tool" role="button" tabindex="0">Gemini Flash Quota <span class="sort-arrow"></span></th>
+                            <th data-sort-key="sub" role="button" tabindex="0">Claude + GPT Quota <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="search" role="button" tabindex="0">Gemini Pro Quota <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="tool" role="button" tabindex="0">Gemini Flash Quota <span
+                                    class="sort-arrow"></span></th>
                             {{else if eq .CurrentProvider "gemini"}}
-                            <th data-sort-key="sub" role="button" tabindex="0">Peak Usage <span class="sort-arrow"></span></th>
-                            <th data-sort-key="search" role="button" tabindex="0">Session Δ <span class="sort-arrow"></span></th>
-                            <th data-sort-key="tool" role="button" tabindex="0">Snapshots <span class="sort-arrow"></span></th>
+                            <th data-sort-key="sub" role="button" tabindex="0">Peak Usage <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="search" role="button" tabindex="0">Session Δ <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="tool" role="button" tabindex="0">Snapshots <span
+                                    class="sort-arrow"></span></th>
                             {{else if eq .CurrentProvider "openrouter"}}
-                            <th data-sort-key="sub" role="button" tabindex="0">Credits Used <span class="sort-arrow"></span></th>
-                            <th data-sort-key="search" role="button" tabindex="0">Session Δ <span class="sort-arrow"></span></th>
-                            <th data-sort-key="tool" role="button" tabindex="0">Snapshots <span class="sort-arrow"></span></th>
+                            <th data-sort-key="sub" role="button" tabindex="0">Credits Used <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="search" role="button" tabindex="0">Session Δ <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="tool" role="button" tabindex="0">Snapshots <span
+                                    class="sort-arrow"></span></th>
                             {{else}}
-                            <th data-sort-key="sub" role="button" tabindex="0">Sub Usage <span class="sort-arrow"></span></th>
-                            <th data-sort-key="search" role="button" tabindex="0">Search Usage <span class="sort-arrow"></span></th>
-                            <th data-sort-key="tool" role="button" tabindex="0">Tool Usage <span class="sort-arrow"></span></th>
+                            <th data-sort-key="sub" role="button" tabindex="0">Sub Usage <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="search" role="button" tabindex="0">Search Usage <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="tool" role="button" tabindex="0">Tool Usage <span
+                                    class="sort-arrow"></span></th>
                             {{end}}
                         </tr>
                     </thead>
@@ -567,8 +656,8 @@
             <header class="section-header">
                 <h3 class="section-title">
                     <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/>
-                        <path d="M3 3v5h5"/>
+                        <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+                        <path d="M3 3v5h5" />
                     </svg>
                     {{if eq .CurrentProvider "cursor"}}Usage Samples{{else}}Logging History{{end}}
                 </h3>
@@ -585,7 +674,8 @@
                     </div>
                     <div class="filter-group">
                         <span class="filter-label">{{if eq .CurrentProvider "cursor"}}Bucket{{else}}Group{{end}}</span>
-                        <div class="filter-pills" id="cycles-bucket-pills" role="group" aria-label="Polling grouping window">
+                        <div class="filter-pills" id="cycles-bucket-pills" role="group"
+                            aria-label="Polling grouping window">
                             <!-- Populated dynamically from poll interval -->
                         </div>
                     </div>
@@ -601,23 +691,30 @@
                 <table class="data-table" id="cycles-table">
                     <thead id="cycles-thead">
                         <tr>
-                            <th data-sort-key="id" role="button" tabindex="0">Cycle <span class="sort-arrow"></span></th>
-                            <th data-sort-key="start" role="button" tabindex="0">Start <span class="sort-arrow"></span></th>
+                            <th data-sort-key="id" role="button" tabindex="0">Cycle <span class="sort-arrow"></span>
+                            </th>
+                            <th data-sort-key="start" role="button" tabindex="0">Start <span class="sort-arrow"></span>
+                            </th>
                             <th data-sort-key="end" role="button" tabindex="0">End <span class="sort-arrow"></span></th>
-                            <th data-sort-key="duration" role="button" tabindex="0">Duration <span class="sort-arrow"></span></th>
-                            <th data-sort-key="totalDelta" role="button" tabindex="0">Total Δ <span class="sort-arrow"></span></th>
+                            <th data-sort-key="duration" role="button" tabindex="0">Duration <span
+                                    class="sort-arrow"></span></th>
+                            <th data-sort-key="totalDelta" role="button" tabindex="0">Total Δ <span
+                                    class="sort-arrow"></span></th>
                         </tr>
                     </thead>
                     <tbody id="cycles-tbody">
                         <tr>
-                            <td colspan="5" class="empty-state">{{if eq .CurrentProvider "cursor"}}No usage samples yet. Cursor tracking begins after the first successful sync.{{else}}No polling data yet. Tracking begins on first poll.{{end}}</td>
+                            <td colspan="5" class="empty-state">{{if eq .CurrentProvider "cursor"}}No usage samples yet.
+                                Cursor tracking begins after the first successful sync.{{else}}No polling data yet.
+                                Tracking begins on first poll.{{end}}</td>
                         </tr>
                     </tbody>
                 </table>
             </div>
             <div class="table-footer">
                 <span class="table-info" id="cycles-info">Showing 0-0 of 0</span>
-                <span class="table-legend">{{if eq .CurrentProvider "cursor"}}Δ = change since previous sample{{else}}⚡ = consumption rate per hour{{end}}</span>
+                <span class="table-legend">{{if eq .CurrentProvider "cursor"}}Δ = change since previous sample{{else}}⚡
+                    = consumption rate per hour{{end}}</span>
                 <div class="table-pagination" id="cycles-pagination"></div>
             </div>
         </section>
@@ -626,14 +723,15 @@
             <header class="section-header">
                 <h3 class="section-title">
                     <svg class="section-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M12 20V10M18 20V4M6 20v-4"/>
+                        <path d="M12 20V10M18 20V4M6 20v-4" />
                     </svg>
                     {{if eq .CurrentProvider "cursor"}}Billing Cycle Overview{{else}}Cycle Overview{{end}}
                 </h3>
                 <div class="cycles-filters-inline">
                     <div class="filter-group">
                         <span class="filter-label">{{if eq .CurrentProvider "cursor"}}Quota{{else}}Period{{end}}</span>
-                        <div class="filter-pills" id="overview-period-pills" role="group" aria-label="Renewal period"></div>
+                        <div class="filter-pills" id="overview-period-pills" role="group" aria-label="Renewal period">
+                        </div>
                     </div>
                     <select class="page-size-select" id="overview-page-size" aria-label="Rows per page">
                         <option value="10">10</option>
@@ -645,15 +743,23 @@
             </header>
             <div class="table-wrapper">
                 <table class="data-table" id="overview-table">
-                    <thead id="overview-thead"><tr><th>Loading...</th></tr></thead>
+                    <thead id="overview-thead">
+                        <tr>
+                            <th>Loading...</th>
+                        </tr>
+                    </thead>
                     <tbody id="overview-tbody">
-                        <tr><td class="empty-state">{{if eq .CurrentProvider "cursor"}}Select a quota to compare monthly billing cycles.{{else}}Select a renewal period to view cross-quota data.{{end}}</td></tr>
+                        <tr>
+                            <td class="empty-state">{{if eq .CurrentProvider "cursor"}}Select a quota to compare monthly
+                                billing cycles.{{else}}Select a renewal period to view cross-quota data.{{end}}</td>
+                        </tr>
                     </tbody>
                 </table>
             </div>
             <div class="table-footer">
                 <span class="table-info" id="overview-info">Showing 0-0 of 0</span>
-                <span class="table-legend">{{if eq .CurrentProvider "cursor"}}Monthly cycle comparison by quota{{else}}⚡ = consumption rate per hour{{end}}</span>
+                <span class="table-legend">{{if eq .CurrentProvider "cursor"}}Monthly cycle comparison by quota{{else}}⚡
+                    = consumption rate per hour{{end}}</span>
                 <div class="table-pagination" id="overview-pagination"></div>
             </div>
         </section>
@@ -662,19 +768,23 @@
 
     <footer class="app-footer">
         <div class="footer-content">
-            <span class="footer-brand"><a href="https://onwatch.onllm.dev" class="footer-link" target="_blank" rel="noopener">onWatch v{{.Version}}</a></span>
+            <span class="footer-brand"><a href="https://onwatch.onllm.dev" class="footer-link" target="_blank"
+                    rel="noopener">onWatch v{{.Version}}</a></span>
             <span id="update-badge" class="footer-update" hidden>
                 <button id="update-btn" class="footer-update-btn" title="Click to update">
                     Update to v<span id="update-version"></span>
                 </button>
             </span>
-            <span class="footer-heart">Built with &#10084;&#65039; by <a href="https://onllm.dev" class="footer-link" target="_blank" rel="noopener">onllm.dev</a></span>
+            <span class="footer-heart">Built with &#10084;&#65039; by <a href="https://onllm.dev" class="footer-link"
+                    target="_blank" rel="noopener">onllm.dev</a></span>
             <div class="footer-links">
                 <a href="https://onllm.dev" class="footer-link" target="_blank" rel="noopener">onllm.dev</a>
                 <span class="footer-sep">&#183;</span>
-                <a href="https://github.com/onllm-dev/onwatch" class="footer-link" target="_blank" rel="noopener">GitHub</a>
+                <a href="https://github.com/onllm-dev/onwatch" class="footer-link" target="_blank"
+                    rel="noopener">GitHub</a>
                 <span class="footer-sep">&#183;</span>
-                <a href="https://buymeacoffee.com/prakersh" class="footer-link footer-support" target="_blank" rel="noopener" title="Support onWatch">Support onWatch</a>
+                <a href="https://buymeacoffee.com/prakersh" class="footer-link footer-support" target="_blank"
+                    rel="noopener" title="Support onWatch">Support onWatch</a>
             </div>
         </div>
     </footer>
@@ -688,7 +798,7 @@
             <h2 class="modal-title" id="modal-title">Quota Details</h2>
             <button class="modal-close" id="modal-close" aria-label="Close modal">
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M18 6L6 18M6 6l12 12"/>
+                    <path d="M18 6L6 18M6 6l12 12" />
                 </svg>
             </button>
         </header>

--- a/main.go
+++ b/main.go
@@ -819,6 +819,21 @@ func run() error {
 		logger.Info("Cursor API client configured")
 	}
 
+	var opencodeClient *api.OpenCodeClient
+	if cfg.HasProvider("opencode") {
+		opencodeCookie := cfg.OpenCodeCookie
+		if opencodeCookie == "" {
+			if cookie := api.DetectOpenCodeCookie(logger); cookie != "" {
+				opencodeCookie = cookie
+				cfg.OpenCodeAutoCookie = true
+			}
+		}
+		if opencodeCookie != "" {
+			opencodeClient = api.NewOpenCodeClient(opencodeCookie, logger)
+			logger.Info("OpenCode API client configured")
+		}
+	}
+
 	// Create components
 	tr := tracker.New(db, logger)
 
@@ -985,6 +1000,11 @@ func run() error {
 		cursorTr = tracker.NewCursorTracker(db, logger)
 	}
 
+	var opencodeTr *tracker.OpenCodeTracker
+	if cfg.HasProvider("opencode") {
+		opencodeTr = tracker.NewOpenCodeTracker(db, logger)
+	}
+
 	var antigravityAg *agent.AntigravityAgent
 	if antigravityClient != nil {
 		antigravitySm := agent.NewSessionManager(db, "antigravity", idleTimeout, logger)
@@ -1043,6 +1063,15 @@ func run() error {
 		})
 	}
 
+	var opencodeAg *agent.OpenCodeAgent
+	if opencodeClient != nil {
+		opencodeSm := agent.NewSessionManager(db, "opencode", idleTimeout, logger)
+		opencodeAg = agent.NewOpenCodeAgent(opencodeClient, db, opencodeTr, cfg.PollInterval, logger, opencodeSm)
+		opencodeAg.SetCookieRefresh(func() string {
+			return cfg.OpenCodeCookie
+		})
+	}
+
 	var apiIntegrationsAg *agent.APIIntegrationsIngestAgent
 	if cfg.APIIntegrationsEnabled {
 		apiIntegrationsAg = agent.NewAPIIntegrationsIngestAgent(db, cfg.APIIntegrationsDir, cfg.APIIntegrationsRetention, logger)
@@ -1086,6 +1115,9 @@ func run() error {
 	}
 	if cursorAg != nil {
 		cursorAg.SetNotifier(notifier)
+	}
+	if opencodeAg != nil {
+		opencodeAg.SetNotifier(notifier)
 	}
 
 	// Wire polling checks - agents skip poll when telemetry disabled
@@ -1191,6 +1223,9 @@ func run() error {
 	if cursorAg != nil {
 		cursorAg.SetPollingCheck(func() bool { return isPollingEnabled("cursor") })
 	}
+	if opencodeAg != nil {
+		opencodeAg.SetPollingCheck(func() bool { return isPollingEnabled("opencode") })
+	}
 
 	// Wire reset callbacks to trackers
 	tr.SetOnReset(func(quotaName string) {
@@ -1241,6 +1276,11 @@ func run() error {
 			notifier.Check(notify.QuotaStatus{Provider: "cursor", QuotaKey: quotaName, ResetOccurred: true})
 		})
 	}
+	if opencodeTr != nil {
+		opencodeTr.SetOnReset(func(quotaName string) {
+			notifier.Check(notify.QuotaStatus{Provider: "opencode", QuotaKey: quotaName, ResetOccurred: true})
+		})
+	}
 
 	handler := web.NewHandler(db, tr, logger, nil, cfg, zaiTr)
 	handler.SetVersion(version)
@@ -1268,6 +1308,9 @@ func run() error {
 	}
 	if cursorTr != nil {
 		handler.SetCursorTracker(cursorTr)
+	}
+	if opencodeTr != nil {
+		handler.SetOpenCodeTracker(opencodeTr)
 	}
 	agentMgr := agent.NewAgentManager(logger)
 	if ag != nil {
@@ -1300,6 +1343,9 @@ func run() error {
 	if cursorAg != nil {
 		agentMgr.RegisterFactory("cursor", func() (agent.AgentRunner, error) { return cursorAg, nil })
 	}
+	if opencodeAg != nil {
+		agentMgr.RegisterFactory("opencode", func() (agent.AgentRunner, error) { return opencodeAg, nil })
+	}
 
 	if apiIntegrationsAg != nil {
 		agentMgr.RegisterFactory("api_integrations", func() (agent.AgentRunner, error) { return apiIntegrationsAg, nil })
@@ -1326,7 +1372,7 @@ func run() error {
 
 	// Start configured agents through the manager.
 	startedAny := false
-	for _, providerKey := range []string{"synthetic", "zai", "anthropic", "copilot", "codex", "antigravity", "minimax", "openrouter", "gemini", "cursor"} {
+	for _, providerKey := range []string{"synthetic", "zai", "anthropic", "copilot", "codex", "antigravity", "minimax", "openrouter", "gemini", "cursor", "opencode"} {
 		if !isPollingEnabled(providerKey) {
 			continue
 		}


### PR DESCRIPTION
### Summary
Adds full telemetry tracking support for the OpenCode GO provider, enabling quota monitoring via cookie-based authentication against the OpenCode platform.

### What Changed

**New Provider Implementation**
- internal/api/opencode_client.go — HTTP client for OpenCode API with cookie-based auth, workspace auto-discovery, and usage page scraping
- internal/api/opencode_types.go — Data models for OpenCode snapshots and quotas (rolling, weekly, monthly)
- internal/agent/opencode_agent.go — Background polling agent with cookie refresh, auth-failure backoff, and automatic retry logic
- internal/tracker/opencode_tracker.go — Cycle-based usage tracker with reset detection and rate projection
- internal/web/opencode_handlers.go — REST handlers for current usage, history, and cycle endpoints
- internal/store/opencode_store.go — Persistence layer for OpenCode snapshots and cycles

**Configuration & Bootstrap**
- internal/config/config.go — Added OPENCODE_COOKIE env var, auto-detection flag, and provider registry integration
- main.go — Wired OpenCode client, agent, tracker, and notifier into the application lifecycle

**Web Dashboard**
- internal/web/static/app.js — Added OpenCode provider rendering, charts, and real-time updates
- internal/web/templates/dashboard.html — New OpenCode quota cards and history sections
- internal/web/handlers.go & server.go — Registered OpenCode routes and injected tracker dependencies

**Testing**
- internal/api/opencode_client_test.go
- internal/api/opencode_types_test.go
- internal/tracker/opencode_tracker_test.go
- internal/web/opencode_handlers_test.go

**Screenshots**
<img width="1360" height="535" alt="chrome_UVGoJDUV5w" src="https://github.com/user-attachments/assets/52e98557-25f9-4dd1-ab78-d2e7c2a3ceb2" />
<img width="921" height="410" alt="image" src="https://github.com/user-attachments/assets/da75895d-ba53-4000-8195-903c00dc954c" />
