### PR TITLE
fix(menubar): open dashboard on configured port, not hardcoded 9211

### DIFF
--- a/internal/menubar/popover_darwin.m
+++ b/internal/menubar/popover_darwin.m
@@ -426,9 +426,20 @@ static void onwatch_run_on_main_sync(dispatch_block_t block) {
   }
 
   if ([action isEqualToString:@"open_dashboard"]) {
-    NSURL *url = [NSURL URLWithString:@"http://localhost:9211"];
-    if (url) {
-      [[NSWorkspace sharedWorkspace] openURL:url];
+    // Derive the dashboard origin from the webview's own URL so we honor the
+    // runtime port (ONWATCH_PORT / --port) without threading it through CGO.
+    NSURL *current = self.webView.URL;
+    if (!current || ![self isLocalURL:current]) {
+      return;
+    }
+    NSURLComponents *components =
+        [NSURLComponents componentsWithURL:current resolvingAgainstBaseURL:NO];
+    components.path = @"";
+    components.query = nil;
+    components.fragment = nil;
+    NSURL *dashboardURL = components.URL;
+    if (dashboardURL) {
+      [[NSWorkspace sharedWorkspace] openURL:dashboardURL];
       [self close];
     }
   }


### PR DESCRIPTION
## Summary

Fixes #65. On macOS, clicking "Open Dashboard" inside the menubar popover opened `http://localhost:9211` regardless of the configured port, so users running with `ONWATCH_PORT=7777` (or `--port`) got a dead URL.

The bug was a single hardcoded literal in `internal/menubar/popover_darwin.m:429`:

```objc
NSURL *url = [NSURL URLWithString:@"http://localhost:9211"];
```

The Go-side tray menu item ("Open Dashboard" via right-click) was already correct - it goes through `c.dashboardURL()` which honors `cfg.Port`. Only the popover's in-page button was broken.

## Approach

Derive the dashboard origin from the `WKWebView`'s own loaded URL rather than threading the port through CGO or accepting one from JS:

```objc
NSURL *current = self.webView.URL;                           // http://localhost:<cfg.Port>/menubar
NSURLComponents *c = [NSURLComponents componentsWithURL:current
                                 resolvingAgainstBaseURL:NO];
c.path = @""; c.query = nil; c.fragment = nil;
NSURL *dashboardURL = c.URL;                                 // http://localhost:<cfg.Port>
```

Why this over alternatives:

- **vs. hardcoded default**: follows the actual runtime port, not a compile-time constant.
- **vs. reading `ONWATCH_PORT` env in Obj-C**: env is a config *input*; the webview's origin reflects the *resolved* port (after flag override, auto-fallback, etc.). Env-reading would also duplicate Go's resolution rules in C.
- **vs. new CGO setter pushing `cfg.Port` into Obj-C state**: no new C symbols, no second copy of the port to keep in sync, no ordering rule ("call setter before show"). The `WKWebView` already holds the authoritative URL.
- **vs. letting JS send the URL in the postMessage body**: no JS contract change, and we don't trust page-supplied URLs.

`isLocalURL:` (already present in this file) still guards against a non-local origin.

## Test plan

- [x] `go vet ./...` clean.
- [x] `go test -race -count=1 ./internal/menubar/... ./internal/web/...` passes (the web package asserts the JS still fires `sendNativeAction("open_dashboard")` - unchanged).
- [x] Audited remaining `9211` and `open_dashboard` references - only the legit `DefaultConfig()` default, CLI banner tests, marketing copy, and the action-name string itself remain.
- [ ] **Requires macOS verification** - the modified file is `//go:build menubar && darwin && cgo`, so Linux can't compile or exercise the Obj-C path. Manual check needed: run `ONWATCH_PORT=7777 onwatch`, open the menubar popover, click "Open Dashboard", confirm the browser opens `http://localhost:7777` (not `:9211`).

Fixes #65

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jjo8pXrPuBkEnmTAaBUj5L)_