### PR TITLE
Handle Anthropic usage metadata arrays

### DIFF
--- a/internal/api/anthropic_client_test.go
+++ b/internal/api/anthropic_client_test.go
@@ -50,6 +50,54 @@ func TestAnthropicClient_FetchQuotas_Success(t *testing.T) {
 	}
 }
 
+func TestAnthropicClient_FetchQuotas_IgnoresLimitsArray(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"five_hour": {
+				"utilization": 12.5,
+				"resets_at": "2026-06-24T04:00:00Z"
+			},
+			"seven_day": {
+				"utilization": 34.5,
+				"resets_at": "2026-06-30T00:00:00Z"
+			},
+			"seven_day_oauth_apps": null,
+			"limits": [
+				{
+					"group": "claude",
+					"kind": "quota",
+					"percent": 12.5,
+					"resets_at": "2026-06-24T04:00:00Z",
+					"is_active": true
+				}
+			],
+			"spend": {
+				"enabled": false,
+				"percent": 0
+			}
+		}`)
+	}))
+	defer server.Close()
+
+	client := api.NewAnthropicClient("test_token", testutil.DiscardLogger(),
+		api.WithAnthropicBaseURL(server.URL),
+	)
+
+	resp, err := client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := resp.ActiveQuotaNames()
+	if got, want := fmt.Sprint(names), "[five_hour seven_day]"; got != want {
+		t.Fatalf("ActiveQuotaNames() = %s, want %s", got, want)
+	}
+	if _, ok := (*resp)["limits"]; ok {
+		t.Fatal("non-quota limits array should be ignored")
+	}
+}
+
 func TestAnthropicClient_FetchQuotas_Headers(t *testing.T) {
 	var gotAuth atomic.Value
 	var gotBeta atomic.Value

--- a/internal/api/anthropic_types.go
+++ b/internal/api/anthropic_types.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"sort"
 	"time"
@@ -19,6 +20,37 @@ type AnthropicQuotaEntry struct {
 // AnthropicQuotaResponse is the full response from the Anthropic usage API.
 // Keys are dynamic (five_hour, seven_day, etc.).
 type AnthropicQuotaResponse map[string]*AnthropicQuotaEntry
+
+// UnmarshalJSON accepts the quota-object values used by the Claude usage API
+// while ignoring top-level metadata fields such as "limits", which Anthropic
+// began returning as arrays in June 2026.
+func (r *AnthropicQuotaResponse) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	resp := make(AnthropicQuotaResponse, len(raw))
+	for key, value := range raw {
+		trimmed := bytes.TrimSpace(value)
+		if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+			resp[key] = nil
+			continue
+		}
+		if trimmed[0] != '{' {
+			continue
+		}
+
+		var entry AnthropicQuotaEntry
+		if err := json.Unmarshal(trimmed, &entry); err != nil {
+			return err
+		}
+		resp[key] = &entry
+	}
+
+	*r = resp
+	return nil
+}
 
 // AnthropicQuota represents a single normalized quota for storage.
 type AnthropicQuota struct {


### PR DESCRIPTION
## Summary

Fixes Anthropic OAuth usage polling when `/api/oauth/usage` includes top-level metadata arrays such as `limits`.

## Root Cause

Anthropic now returns additional top-level fields alongside quota buckets. At least one of those fields, `limits`, is an array. `AnthropicQuotaResponse` currently unmarshals the entire response as `map[string]*AnthropicQuotaEntry`, so any array-valued metadata field fails the whole decode with:

```text
json: cannot unmarshal array into Go value of type api.AnthropicQuotaEntry
```

That matches the failure reported in #82.

## Changes

- Adds a custom `UnmarshalJSON` for `AnthropicQuotaResponse`.
- Preserves quota-object values and `null` inactive buckets.
- Ignores non-object metadata fields such as `limits` arrays.
- Adds a regression test covering the new response shape.

## Validation

- `go test ./internal/api -run 'TestAnthropicClient_FetchQuotas'`
- Also validated the patch against a live Anthropic OAuth usage response in a temporary container before preparing this PR.

Fixes #82.
