### PR TITLE
build(nix): add Nix flake for reproducible builds and dev shell

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,8 @@ onwatch-test
 .omc/
 .omx/
 .playwright-mcp/
+
+# Nix
+/result
+/result-*
+.direnv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,16 @@ internal/
 go test -race ./... && go vet ./...   # Pre-commit (mandatory)
 ```
 
+**Nix (alternative to app.sh, for build + dev shell):**
+
+```bash
+nix build .#onwatch         # Pure-Go static binary -> ./result/bin/onwatch
+nix run .#onwatch           # Build + run
+nix develop                 # Shell with go/gopls/gotools/gofumpt (or `direnv allow`)
+```
+
+On `go.sum` changes, update `vendorHash` in `flake.nix` (run `nix build .#onwatch`, paste the `got: sha256-...` from the error). Flake tracks `nixos-unstable` because `go.mod` requires Go >= 1.25.7.
+
 ## Guardrails
 
 | Rule | Reason |

--- a/README.md
+++ b/README.md
@@ -578,6 +578,20 @@ See [DEVELOPMENT.md](docs/DEVELOPMENT.md) for build instructions, cross-compilat
 ./app.sh --release     # Cross-compile all platforms (or: make release-local)
 ```
 
+### Nix
+
+If you have Nix (flakes enabled), you can build, run, and develop without touching `app.sh`:
+
+```bash
+nix build .#onwatch            # Build -> ./result/bin/onwatch (pure-Go, static)
+nix run .#onwatch -- --debug   # Build + run
+nix develop                    # Enter a shell with go, gopls, gotools, gofumpt
+```
+
+With [direnv](https://direnv.net/) installed, run `direnv allow` once and the devShell loads automatically on `cd`.
+
+The flake tracks `nixos-unstable` (pinned via `flake.lock`) because `go.mod` requires Go >= 1.25.7 and the `nixos-25.05` branch only ships Go 1.24. When you change `go.sum`, update the `vendorHash` in `flake.nix` by running `nix build .#onwatch` and pasting the `got: sha256-...` value from the mismatch error.
+
 ---
 
 ## Contributing

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782467914,
+        "narHash": "sha256-pGvFkM8N0xEkIIXDe5YYfbEAvHrk4IxBrjB/x8OomhE=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e73de5be04e0eff4190a1432b946d469c794e7b4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "onWatch - Go CLI for AI quota tracking";
+
+  inputs = {
+    # nixos-25.05 ships Go 1.24 (and go_1_25 = 1.25.5); go.mod requires
+    # >= 1.25.7, so we track nixos-unstable which defaults to Go 1.26.x.
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+        lib = pkgs.lib;
+        version = builtins.readFile ./VERSION;
+        onwatch = pkgs.buildGoModule {
+          pname = "onwatch";
+          inherit version;
+          src = ./.;
+          subPackages = [ "." ];
+          vendorHash = "sha256-zagPclPZItTTUaMh+8Ph7k5ESqc3vETPNkhMQ493MoY=";
+          ldflags = [
+            "-s"
+            "-w"
+            "-X main.version=${version}"
+          ];
+          env.CGO_ENABLED = 0;
+        };
+      in
+      {
+        packages = {
+          inherit onwatch;
+          default = onwatch;
+        };
+
+        apps.default = {
+          type = "app";
+          program = "${onwatch}/bin/onwatch";
+        };
+
+        devShells.default = pkgs.mkShell {
+          packages = with pkgs; [
+            go
+            gopls
+            gotools
+            gofumpt
+          ];
+        };
+      });
+}


### PR DESCRIPTION
Add flake.nix exposing:

- **packages.onwatch**: static pure-Go binary via `buildGoModule` (tracks nixos-unstable)
- **devShell**: go 1.26.4, gopls, gotools, gofumpt
- **apps.default**: enables `nix run .#onwatch`

Includes:
- `.envrc` for direnv integration
- `.gitignore` updates for `result/`
- Nix documentation in README.md and CLAUDE.md

**Why nixos-unstable?** The `go.mod` requires Go >= 1.25.7, but `nixos-25.05` only ships Go 1.24 (and `go_1_25` = 1.25.5). The flake tracks `nixos-unstable` which defaults to Go 1.26.x, satisfying the requirement while providing a reproducible, pinned toolchain.

**vendorHash**: Pinned from `go.sum` (sha256-zagPclPZItTTUaMh+8Ph7k5ESqc3vETPNkhMQ493MoY=). On `go.sum` changes, update this hash by running `nix build .#onwatch` and pasting the `got: sha256-...` value from the mismatch error.

**Usage**:
```bash
nix build .#onwatch      # Build -> ./result/bin/onwatch
nix run .#onwatch         # Build + run
nix develop               # Enter dev shell (or `direnv allow`)
```

See the "Nix" section in README.md for details.