### PR TITLE
fix(anthropic): tolerate mixed non-object values in usage response

### DIFF
--- a/internal/api/anthropic_client.go
+++ b/internal/api/anthropic_client.go
@@ -155,7 +155,15 @@ func (c *AnthropicClient) FetchQuotas(ctx context.Context) (*AnthropicQuotaRespo
 
 	var quotaResp AnthropicQuotaResponse
 	if err := json.Unmarshal(body, &quotaResp); err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrAnthropicInvalidResponse, err)
+		// The Anthropic usage API returns a JSON array (e.g. `[]`) instead of an
+		// object when the account currently has no active quota windows. Treat
+		// that shape as an empty quota set rather than a hard parse error.
+		var arr []json.RawMessage
+		if arrErr := json.Unmarshal(body, &arr); arrErr == nil {
+			quotaResp = AnthropicQuotaResponse{}
+		} else {
+			return nil, fmt.Errorf("%w: %v", ErrAnthropicInvalidResponse, err)
+		}
 	}
 
 	// Log active quota names on success

--- a/internal/api/anthropic_types.go
+++ b/internal/api/anthropic_types.go
@@ -16,6 +16,31 @@ type AnthropicQuotaEntry struct {
 	UsedCredits  *float64 `json:"used_credits,omitempty"`
 }
 
+// UnmarshalJSON tolerates the Anthropic usage API returning a JSON array (e.g.
+// `[]`) for a quota value when that window is inactive, instead of the expected
+// object. An array is treated as an empty (inactive) entry rather than a hard
+// parse error.
+func (e *AnthropicQuotaEntry) UnmarshalJSON(data []byte) error {
+	trimmed := data
+	for len(trimmed) > 0 && (trimmed[0] == ' ' || trimmed[0] == '\t' || trimmed[0] == '\n' || trimmed[0] == '\r') {
+		trimmed = trimmed[1:]
+	}
+	// The Anthropic usage API mixes quota-object values with non-object values
+	// under the same top-level map (e.g. `limits: [...]`, scalar flags). Any
+	// value that is not a JSON object is treated as an inactive/absent quota
+	// entry rather than a hard parse error.
+	if len(trimmed) == 0 || trimmed[0] != '{' {
+		return nil
+	}
+	type entryAlias AnthropicQuotaEntry
+	var alias entryAlias
+	if err := json.Unmarshal(data, &alias); err != nil {
+		return err
+	}
+	*e = AnthropicQuotaEntry(alias)
+	return nil
+}
+
 // AnthropicQuotaResponse is the full response from the Anthropic usage API.
 // Keys are dynamic (five_hour, seven_day, etc.).
 type AnthropicQuotaResponse map[string]*AnthropicQuotaEntry

--- a/internal/api/anthropic_types_coverage_test.go
+++ b/internal/api/anthropic_types_coverage_test.go
@@ -132,6 +132,46 @@ func TestParseAnthropicResponse_InvalidJSON(t *testing.T) {
 	}
 }
 
+// TestParseAnthropicResponse_MixedNonObjectValues reproduces the current shape
+// of the /api/oauth/usage response, where the top-level object mixes quota
+// objects with non-object values (a "limits" array and null placeholders).
+// These non-object values must be tolerated instead of causing a hard
+// "cannot unmarshal array/bool into AnthropicQuotaEntry" error.
+func TestParseAnthropicResponse_MixedNonObjectValues(t *testing.T) {
+	data := []byte(`{
+		"five_hour": {"utilization": 10.0, "resets_at": "2026-07-14T11:10:00Z"},
+		"seven_day": {"utilization": 9.0, "resets_at": "2026-07-19T21:00:00Z"},
+		"seven_day_sonnet": null,
+		"extra_usage": {"is_enabled": true, "utilization": 37.4},
+		"limits": [
+			{"kind": "session", "percent": 10, "is_active": true},
+			{"kind": "weekly_all", "percent": 9, "is_active": false}
+		]
+	}`)
+
+	resp, err := ParseAnthropicResponse(data)
+	if err != nil {
+		t.Fatalf("ParseAnthropicResponse should tolerate mixed values, got: %v", err)
+	}
+	if resp == nil {
+		t.Fatal("response should not be nil")
+	}
+
+	if entry := (*resp)["five_hour"]; entry == nil || entry.Utilization == nil || *entry.Utilization != 10.0 {
+		t.Errorf("five_hour utilization not parsed correctly: %+v", entry)
+	}
+	if entry := (*resp)["seven_day"]; entry == nil || entry.Utilization == nil || *entry.Utilization != 9.0 {
+		t.Errorf("seven_day utilization not parsed correctly: %+v", entry)
+	}
+
+	// The "limits" array value must be ignored (not surfaced as an active quota).
+	for _, name := range resp.ActiveQuotaNames() {
+		if name == "limits" {
+			t.Error("limits array should not be treated as an active quota")
+		}
+	}
+}
+
 func TestRedactAnthropicToken(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Problem

On accounts where the Anthropic usage API (`GET /api/oauth/usage`) returns the
current response shape, onWatch fails to fetch Anthropic quotas with:

```
anthropic: invalid response: json: cannot unmarshal array into Go value of type api.AnthropicQuotaEntry
```

(also observed as `cannot unmarshal bool ...` depending on the payload).

The endpoint now returns a **top-level object that mixes quota objects with
non-object values** - notably a `"limits": [ ... ]` array and `null`
placeholders for inactive windows:

```jsonc
{
  "five_hour":  { "utilization": 10.0, "resets_at": "..." },
  "seven_day":  { "utilization": 9.0,  "resets_at": "..." },
  "seven_day_sonnet": null,
  "extra_usage": { "is_enabled": true, "utilization": 37.4, ... },
  "limits": [ { "kind": "session", "percent": 10, "is_active": true }, ... ]
}
```

Since `AnthropicQuotaResponse` is a `map[string]*AnthropicQuotaEntry`, decoding
the `limits` array (and other non-object values) into `AnthropicQuotaEntry`
aborts the whole parse, so **no Anthropic quota is ever recorded** for these
accounts.

## Fix

- Add `AnthropicQuotaEntry.UnmarshalJSON` that treats any **non-object** JSON
  value (array, scalar, `null`) as an absent/inactive entry instead of a hard
  error. Object values keep parsing exactly as before.
- Keep the existing array-at-root guard in `anthropic_client.go`.
- Unknown keys such as `limits` are still filtered out downstream by the
  existing `anthropicDisplayNames` whitelist, so nothing new reaches storage or
  the UI.

## Test

Adds `TestParseAnthropicResponse_MixedNonObjectValues`, reproducing the real
response shape (quota objects + `null` + `limits` array) and asserting that
`five_hour`/`seven_day` still parse and that `limits` is never surfaced as an
active quota.

Verified locally against a live `Max 5x` account: the dashboard now shows
`5-Hour`, `Weekly All-Model` and `Extra Usage` correctly.