### PR TITLE
fix(anthropic): tolerate usage API metadata fields (limits/spend)

### DIFF
--- a/internal/api/anthropic_client_test.go
+++ b/internal/api/anthropic_client_test.go
@@ -50,6 +50,72 @@ func TestAnthropicClient_FetchQuotas_Success(t *testing.T) {
 	}
 }
 
+// Regression for #82 / #84: /api/oauth/usage now includes top-level metadata
+// such as limits (array) and spend (unrelated object). Decoding must still
+// return the quota buckets and must not store metadata keys as quota entries.
+func TestAnthropicClient_FetchQuotas_IgnoresUsageMetadataFields(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{
+			"five_hour": {
+				"utilization": 12.5,
+				"resets_at": "2026-06-24T04:00:00Z"
+			},
+			"seven_day": {
+				"utilization": 34.5,
+				"resets_at": "2026-06-30T00:00:00Z"
+			},
+			"seven_day_oauth_apps": null,
+			"limits": [
+				{
+					"group": "claude",
+					"kind": "quota",
+					"percent": 12.5,
+					"resets_at": "2026-06-24T04:00:00Z",
+					"is_active": true
+				}
+			],
+			"spend": {
+				"enabled": false,
+				"percent": 0,
+				"used": {"amount_minor": 0, "currency": "USD", "exponent": 2}
+			},
+			"member_dashboard_available": false
+		}`)
+	}))
+	defer server.Close()
+
+	client := api.NewAnthropicClient("test_token", testutil.DiscardLogger(),
+		api.WithAnthropicBaseURL(server.URL),
+	)
+
+	resp, err := client.FetchQuotas(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	names := resp.ActiveQuotaNames()
+	if got, want := fmt.Sprint(names), "[five_hour seven_day]"; got != want {
+		t.Fatalf("ActiveQuotaNames() = %s, want %s", got, want)
+	}
+	if _, ok := (*resp)["limits"]; ok {
+		t.Fatal("non-quota limits array should be ignored")
+	}
+	if _, ok := (*resp)["spend"]; ok {
+		t.Fatal("non-quota spend object should be ignored")
+	}
+	if _, ok := (*resp)["member_dashboard_available"]; ok {
+		t.Fatal("boolean companion field should be ignored")
+	}
+	if entry := (*resp)["seven_day_oauth_apps"]; entry != nil {
+		t.Fatal("null quota keys should map to nil entries")
+	}
+	five := (*resp)["five_hour"]
+	if five == nil || five.Utilization == nil || *five.Utilization != 12.5 {
+		t.Fatalf("five_hour utilization = %v, want 12.5", five)
+	}
+}
+
 func TestAnthropicClient_FetchQuotas_Headers(t *testing.T) {
 	var gotAuth atomic.Value
 	var gotBeta atomic.Value

--- a/internal/api/anthropic_types.go
+++ b/internal/api/anthropic_types.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"sort"
 	"time"
@@ -18,7 +19,78 @@ type AnthropicQuotaEntry struct {
 
 // AnthropicQuotaResponse is the full response from the Anthropic usage API.
 // Keys are dynamic (five_hour, seven_day, etc.).
+//
+// Anthropic also returns non-quota companion fields at the top level (e.g.
+// "limits" as an array, "spend" as an unrelated object, booleans). Custom
+// UnmarshalJSON keeps only null/object values that look like quota entries so
+// those metadata fields do not fail the whole decode (see #82 / #84).
 type AnthropicQuotaResponse map[string]*AnthropicQuotaEntry
+
+// UnmarshalJSON accepts the quota-object values used by the Claude usage API
+// while ignoring top-level metadata fields such as "limits" (array) and
+// "spend" (non-quota object), which Anthropic began returning in 2026.
+//
+// Compared with a minimal "skip non-objects" decoder, this also:
+//   - drops objects that share no AnthropicQuotaEntry fields (e.g. spend)
+//   - skips a single bad key instead of failing the entire response, so future
+//     companion objects cannot take down Anthropic polling again
+func (r *AnthropicQuotaResponse) UnmarshalJSON(data []byte) error {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	resp := make(AnthropicQuotaResponse, len(raw))
+	for key, value := range raw {
+		trimmed := bytes.TrimSpace(value)
+		if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) {
+			resp[key] = nil
+			continue
+		}
+		// Quota entries are JSON objects. Skip arrays/scalars (limits[],
+		// member_dashboard_available, …).
+		if trimmed[0] != '{' {
+			continue
+		}
+		// Drop companion objects that do not look like quota buckets (spend, …).
+		if !looksLikeAnthropicQuotaObject(trimmed) {
+			continue
+		}
+
+		var entry AnthropicQuotaEntry
+		if err := json.Unmarshal(trimmed, &entry); err != nil {
+			// Forward-compat: one unreadable companion/experimental object must
+			// not discard five_hour / seven_day and the rest of the payload.
+			continue
+		}
+		e := entry
+		resp[key] = &e
+	}
+
+	*r = resp
+	return nil
+}
+
+// looksLikeAnthropicQuotaObject reports whether a JSON object has at least one
+// field belonging to AnthropicQuotaEntry.
+func looksLikeAnthropicQuotaObject(val json.RawMessage) bool {
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(val, &probe); err != nil {
+		return false
+	}
+	for _, field := range []string{
+		"utilization",
+		"resets_at",
+		"is_enabled",
+		"monthly_limit",
+		"used_credits",
+	} {
+		if _, ok := probe[field]; ok {
+			return true
+		}
+	}
+	return false
+}
 
 // AnthropicQuota represents a single normalized quota for storage.
 type AnthropicQuota struct {

--- a/internal/api/anthropic_types_coverage_test.go
+++ b/internal/api/anthropic_types_coverage_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"testing"
 	"time"
 )
@@ -121,6 +122,63 @@ func TestParseAnthropicResponse_Valid(t *testing.T) {
 	}
 	if *entry.Utilization != 45.2 {
 		t.Errorf("utilization = %f, want 45.2", *entry.Utilization)
+	}
+}
+
+func TestParseAnthropicResponse_IgnoresUsageMetadataFields(t *testing.T) {
+	// Shape observed from live /api/oauth/usage after mid-2026: quota objects
+	// mixed with limits (array), spend (unrelated object), and booleans.
+	data := []byte(`{
+		"five_hour": {
+			"utilization": 7.0,
+			"resets_at": "2026-07-14T20:50:00.062179+00:00",
+			"limit_dollars": null
+		},
+		"seven_day": {
+			"utilization": 10.0,
+			"resets_at": "2026-07-20T18:00:00.062201+00:00"
+		},
+		"seven_day_oauth_apps": null,
+		"extra_usage": {
+			"is_enabled": false,
+			"monthly_limit": null,
+			"used_credits": null,
+			"utilization": null
+		},
+		"limits": [
+			{"kind": "session", "group": "session", "percent": 7, "severity": "normal"}
+		],
+		"spend": {
+			"used": {"amount_minor": 0, "currency": "USD", "exponent": 2},
+			"percent": 0,
+			"enabled": false
+		},
+		"member_dashboard_available": false
+	}`)
+
+	resp, err := ParseAnthropicResponse(data)
+	if err != nil {
+		t.Fatalf("ParseAnthropicResponse failed: %v", err)
+	}
+	if _, ok := (*resp)["limits"]; ok {
+		t.Fatal("limits array must not become a quota entry")
+	}
+	if _, ok := (*resp)["spend"]; ok {
+		t.Fatal("spend object must not become a quota entry")
+	}
+	if _, ok := (*resp)["member_dashboard_available"]; ok {
+		t.Fatal("boolean companion field must not become a quota entry")
+	}
+	if entry := (*resp)["seven_day_oauth_apps"]; entry != nil {
+		t.Fatal("null quota keys should map to nil entries")
+	}
+	// extra_usage is a real quota-shaped object (is_enabled present) and must be kept.
+	if entry := (*resp)["extra_usage"]; entry == nil || entry.IsEnabled == nil || *entry.IsEnabled {
+		t.Fatalf("extra_usage should be kept with is_enabled=false, got %#v", entry)
+	}
+	names := resp.ActiveQuotaNames()
+	if got, want := fmt.Sprint(names), "[five_hour seven_day]"; got != want {
+		t.Fatalf("ActiveQuotaNames() = %s, want %s", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes Anthropic OAuth usage polling when `/api/oauth/usage` includes top-level metadata fields such as `limits` (array), `spend` (unrelated object), and booleans.

This is an enhanced take on #84 (same root cause / same minimal approach), with two robustness improvements observed against a live mid-2026 usage payload.

Fixes #82.
Related: #84.

## Root cause

`AnthropicQuotaResponse` was `map[string]*AnthropicQuotaEntry`. Anthropic now returns companion top-level fields; `limits` is an array, so the whole decode fails with:

```text
json: cannot unmarshal array into Go value of type api.AnthropicQuotaEntry
```

Auth/token refresh is fine — only response-schema decoding breaks.

## Changes

- Custom `UnmarshalJSON` for `AnthropicQuotaResponse`
- Keeps quota objects and `null` inactive buckets
- Ignores non-object metadata (`limits[]`, booleans, …)
- **Enhancement over #84:** also drops non-quota **objects** that share no `AnthropicQuotaEntry` fields (e.g. `spend`), instead of leaving empty entries in the map
- **Enhancement over #84:** per-key decode errors are skipped so one bad companion/experimental object cannot take down the entire poll
- Client + unit regression tests covering the live-ish response shape

## Test plan

- [x] `go test ./internal/api -count=1 -run 'Anthropic|ParseAnthropic'`
- [x] Branch is based on `onllm-dev/onWatch@main` and contains **only this fix** (single commit)
- [ ] CI green on this PR

```bash
go test ./internal/api -count=1 -run 'Anthropic|ParseAnthropic'
```