### PR TITLE
fix(menubar): order tray % metrics by providers_order

### DIFF
--- a/internal/menubar/config.go
+++ b/internal/menubar/config.go
@@ -1,6 +1,7 @@
 package menubar
 
 import (
+	"sort"
 	"strings"
 	"time"
 )
@@ -218,12 +219,59 @@ func (s *Settings) Normalize() *Settings {
 	}
 	out.VisibleProviders = normalizedStringList(out.VisibleProviders)
 	out.StatusDisplay = out.StatusDisplay.normalize(defaults.StatusDisplay)
+	// Tray title metrics must follow the same left-to-right order as the
+	// menubar provider list. selected_quotas may be stored in click order;
+	// re-sort by providers_order at normalize time so every consumer agrees.
+	if out.StatusDisplay.Mode == StatusDisplayMultiProvider {
+		out.StatusDisplay.SelectedQuotas = orderSelectionsByProvidersOrder(
+			out.StatusDisplay.SelectedQuotas,
+			out.ProvidersOrder,
+		)
+	}
 	switch out.Theme {
 	case ThemeSystem, ThemeLight, ThemeDark:
 	default:
 		out.Theme = ThemeSystem
 	}
 	return &out
+}
+
+// orderSelectionsByProvidersOrder reorders tray selections to match
+// providers_order. Selections whose provider is absent from the order keep
+// their relative position after the ordered ones (stable).
+func orderSelectionsByProvidersOrder(selections []StatusDisplaySelection, order []string) []StatusDisplaySelection {
+	if len(selections) <= 1 || len(order) == 0 {
+		return selections
+	}
+	rank := make(map[string]int, len(order))
+	for i, id := range order {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		if _, exists := rank[id]; !exists {
+			rank[id] = i
+		}
+	}
+	if len(rank) == 0 {
+		return selections
+	}
+	out := append([]StatusDisplaySelection(nil), selections...)
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, iok := rank[out[i].ProviderID]
+		rj, jok := rank[out[j].ProviderID]
+		switch {
+		case iok && jok:
+			return ri < rj
+		case iok:
+			return true
+		case jok:
+			return false
+		default:
+			return false
+		}
+	})
+	return out
 }
 
 // ToConfig converts persisted settings into runtime config values.

--- a/internal/menubar/tray_display_test.go
+++ b/internal/menubar/tray_display_test.go
@@ -161,6 +161,55 @@ func TestTrayTitleSingleQuotaIsBare(t *testing.T) {
 	}
 }
 
+// TestTrayTitleFollowsProvidersOrder ensures tray percentages track the
+// menubar provider list order, not the order the quotas were clicked.
+// Repro: providers_order = codex, anthropic, grok but selected_quotas
+// stored as codex, grok, anthropic → was showing 17%·15%·7% instead of
+// 17%·7%·15%.
+func TestTrayTitleFollowsProvidersOrder(t *testing.T) {
+	t.Parallel()
+	snapshot := &Snapshot{
+		Providers: []ProviderCard{
+			{ID: "codex:1", HighestPercent: 17, Quotas: []QuotaMeter{{Key: "weekly_all-model", Percent: 17}}},
+			{ID: "anthropic", HighestPercent: 7, Quotas: []QuotaMeter{{Key: "5-hour_limit", Percent: 7}}},
+			{ID: "grok", HighestPercent: 15, Quotas: []QuotaMeter{{Key: "credits", Percent: 15}}},
+		},
+	}
+	settings := DefaultSettings()
+	settings.ProvidersOrder = []string{"codex:1", "anthropic", "grok", "kimi"}
+	settings.StatusDisplay = StatusDisplay{
+		Mode: StatusDisplayMultiProvider,
+		// Intentionally out of providers_order (click order).
+		SelectedQuotas: []StatusDisplaySelection{
+			{ProviderID: "codex:1", QuotaKey: "weekly_all-model"},
+			{ProviderID: "grok", QuotaKey: "credits"},
+			{ProviderID: "anthropic", QuotaKey: "5-hour_limit"},
+		},
+	}
+
+	got := TrayTitle(snapshot, settings)
+	want := "17%·7%·15%"
+	if got != want {
+		t.Fatalf("TrayTitle() = %q, want %q (providers_order)", got, want)
+	}
+}
+
+func TestOrderSelectionsByProvidersOrder(t *testing.T) {
+	t.Parallel()
+	in := []StatusDisplaySelection{
+		{ProviderID: "grok", QuotaKey: "credits"},
+		{ProviderID: "codex:1", QuotaKey: "weekly"},
+		{ProviderID: "anthropic", QuotaKey: "five_hour"},
+	}
+	got := orderSelectionsByProvidersOrder(in, []string{"codex:1", "anthropic", "grok"})
+	if len(got) != 3 {
+		t.Fatalf("len = %d", len(got))
+	}
+	if got[0].ProviderID != "codex:1" || got[1].ProviderID != "anthropic" || got[2].ProviderID != "grok" {
+		t.Fatalf("order = %#v", got)
+	}
+}
+
 // TestTrayTitleEmptyParts confirms we return empty for empty input.
 func TestTrayTitleEmptyParts(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

macOS menubar tray percentages ignored the configured **provider list order** and followed `selected_quotas` click order instead.

### Repro

- Menubar provider order: Codex → Anthropic → Grok  
- Selected tray quotas (click order): Codex, Grok, Anthropic  
- Shown: `17%·15%·7%` (Codex·Grok·Anthropic)  
- Expected: `17%·7%·15%` (Codex·Anthropic·Grok)

## Root cause

`TrayTitle` walks `status_display.selected_quotas` in storage order. That array is filled when the user toggles quotas and is **not** kept in sync with `providers_order`.

## Fix

During `Settings.Normalize()`, re-sort `selected_quotas` by `providers_order` when mode is `multi_provider`. Every consumer of normalized settings (tray title, preferences API) then matches the menubar list order.

## Test plan

- [x] `go test ./internal/menubar -run 'TrayTitleFollows|OrderSelections'`
- [x] Branch based on `onllm-dev/onWatch@main`, **single commit** only
- [ ] With live menubar: set order Codex / Anthropic / Grok and confirm tray reads left-to-right as that order

## Related

User-facing menubar provider ordering settings; companion of tray multi-provider status display (`selected_quotas`, max 3).