### PR TITLE
fix(menubar): keep Codex visible when settings use bare codex key

### DIFF
--- a/internal/web/menubar.go
+++ b/internal/web/menubar.go
@@ -386,10 +386,7 @@ func (h *Handler) renderMenubarHTML(view menubar.ViewType, settings *menubar.Set
 func (h *Handler) buildMenubarProviderOptions(settings *menubar.Settings) ([]menubarProviderOption, error) {
 	normalized := settings.Normalize()
 	providers, _ := h.buildMenubarProviders(normalized, true)
-	visible := make(map[string]struct{}, len(normalized.VisibleProviders))
-	for _, id := range normalized.VisibleProviders {
-		visible[id] = struct{}{}
-	}
+	visibleKeys := append([]string(nil), normalized.VisibleProviders...)
 	options := make([]menubarProviderOption, 0, len(providers))
 	for _, provider := range providers {
 		quotaOptions := make([]menubarQuotaOption, 0, len(provider.Quotas))
@@ -399,10 +396,7 @@ func (h *Handler) buildMenubarProviderOptions(settings *menubar.Settings) ([]men
 				Label: quota.Label,
 			})
 		}
-		_, isVisible := visible[provider.ID]
-		if len(visible) == 0 {
-			isVisible = true
-		}
+		isVisible := len(visibleKeys) == 0 || menubarSettingsKeyAllows(provider.ID, visibleKeys)
 		options = append(options, menubarProviderOption{
 			ID:           provider.ID,
 			BaseProvider: provider.BaseProvider,
@@ -698,9 +692,23 @@ func sortProviderCards(cards []menubar.ProviderCard, preferred []string) {
 	for idx, key := range preferred {
 		order[key] = idx
 	}
+	rank := func(cardID string) (int, bool) {
+		if idx, ok := order[cardID]; ok {
+			return idx, true
+		}
+		// Settings UI may store base keys ("codex") while cards use
+		// account-scoped IDs ("codex:1").
+		base := providerKeyBase(cardID)
+		if base != cardID {
+			if idx, ok := order[base]; ok {
+				return idx, true
+			}
+		}
+		return 0, false
+	}
 	sort.SliceStable(cards, func(i, j int) bool {
-		leftOrder, leftOK := order[cards[i].ID]
-		rightOrder, rightOK := order[cards[j].ID]
+		leftOrder, leftOK := rank(cards[i].ID)
+		rightOrder, rightOK := rank(cards[j].ID)
 		switch {
 		case leftOK && rightOK:
 			return leftOrder < rightOrder
@@ -720,17 +728,45 @@ func filterMenubarProviders(cards []menubar.ProviderCard, visible []string) []me
 	if len(cards) == 0 || len(visible) == 0 {
 		return cards
 	}
-	allowed := make(map[string]struct{}, len(visible))
-	for _, id := range visible {
-		allowed[id] = struct{}{}
-	}
 	filtered := make([]menubar.ProviderCard, 0, len(cards))
 	for _, card := range cards {
-		if _, ok := allowed[card.ID]; ok {
+		if menubarSettingsKeyAllows(card.ID, visible) {
 			filtered = append(filtered, card)
 		}
 	}
 	return filtered
+}
+
+// menubarSettingsKeyAllows reports whether a menubar card ID is covered by a
+// settings key list (providers_order / visible_providers). Exact match wins;
+// bare base keys like "codex" also match account-scoped cards like "codex:1".
+// Distinct accounts ("codex:1" vs "codex:2") do not match each other.
+func menubarSettingsKeyAllows(cardID string, keys []string) bool {
+	for _, key := range keys {
+		if menubarProviderKeysMatch(cardID, key) {
+			return true
+		}
+	}
+	return false
+}
+
+func menubarProviderKeysMatch(cardID, settingsKey string) bool {
+	cardID = strings.TrimSpace(cardID)
+	settingsKey = strings.TrimSpace(settingsKey)
+	if cardID == "" || settingsKey == "" {
+		return false
+	}
+	if cardID == settingsKey {
+		return true
+	}
+	cardBase := providerKeyBase(cardID)
+	settingsBase := providerKeyBase(settingsKey)
+	if cardBase != settingsBase {
+		return false
+	}
+	// Same family: bare "codex" matches any "codex:N"; specific accounts
+	// only match themselves (handled above).
+	return cardID == cardBase || settingsKey == settingsBase
 }
 
 func parseCapturedAt(payload map[string]interface{}) time.Time {

--- a/internal/web/menubar_test.go
+++ b/internal/web/menubar_test.go
@@ -634,6 +634,59 @@ func findMenubarProviderCard(t *testing.T, snapshot *menubar.Snapshot, providerI
 	return menubar.ProviderCard{}
 }
 
+func TestMenubarProviderKeysMatch(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		card, key string
+		want      bool
+	}{
+		{"codex:1", "codex:1", true},
+		{"codex:1", "codex", true},
+		{"codex", "codex:1", true},
+		{"codex:1", "codex:2", false},
+		{"anthropic", "anthropic", true},
+		{"anthropic", "codex", false},
+		{"minimax:3", "minimax", true},
+		{"", "codex", false},
+	}
+	for _, tc := range cases {
+		if got := menubarProviderKeysMatch(tc.card, tc.key); got != tc.want {
+			t.Fatalf("menubarProviderKeysMatch(%q, %q) = %v, want %v", tc.card, tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestFilterMenubarProvidersAcceptsBareCodexKey(t *testing.T) {
+	t.Parallel()
+	cards := []menubar.ProviderCard{
+		{ID: "codex:1", Label: "Codex - default"},
+		{ID: "anthropic", Label: "Anthropic"},
+		{ID: "grok", Label: "Grok"},
+	}
+	// Web settings previously saved visible_providers as bare "codex", which
+	// exact-matched nothing and dropped Codex from the menubar.
+	got := filterMenubarProviders(cards, []string{"codex", "anthropic", "grok"})
+	if len(got) != 3 {
+		t.Fatalf("filter len = %d, want 3; got %#v", len(got), got)
+	}
+	if got[0].ID != "codex:1" {
+		t.Fatalf("first = %q, want codex:1", got[0].ID)
+	}
+}
+
+func TestSortProviderCardsAcceptsBareCodexOrderKey(t *testing.T) {
+	t.Parallel()
+	cards := []menubar.ProviderCard{
+		{ID: "grok", Label: "Grok"},
+		{ID: "codex:1", Label: "Codex"},
+		{ID: "anthropic", Label: "Anthropic"},
+	}
+	sortProviderCards(cards, []string{"codex", "anthropic", "grok"})
+	if cards[0].ID != "codex:1" || cards[1].ID != "anthropic" || cards[2].ID != "grok" {
+		t.Fatalf("order = %v, %v, %v", cards[0].ID, cards[1].ID, cards[2].ID)
+	}
+}
+
 func assertQuotaLabels(t *testing.T, quotas []menubar.QuotaMeter, want []string) {
 	t.Helper()
 

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -9347,14 +9347,19 @@ async function fetchMenubarProviders() {
     if (res.ok) {
       const data = await res.json();
       const profiles = Array.isArray(data.profiles) ? data.profiles : [];
-      if (profiles.length > 1) {
+      // Always use account-scoped keys (codex:1) so settings match menubar card
+      // IDs. A bare "codex" key used to drop single-account Codex after save
+      // (visible_providers filter is exact-match against "codex:N" cards).
+      if (profiles.length >= 1) {
         profiles.forEach(profile => {
           const key = `codex:${profile.id}`;
           items.push({
             key,
-            name: `Codex - ${escapeHtml(profile.name)}`,
-            meta: 'Per-account Codex usage',
-            dashboardVisible: true,
+            name: profiles.length > 1 ? `Codex - ${escapeHtml(profile.name)}` : (codexStatus?.name || 'Codex'),
+            meta: profiles.length > 1
+              ? 'Per-account Codex usage'
+              : `${codexStatus?.pollingEnabled === false ? 'Telemetry Off' : 'Telemetry On'} · ${codexStatus?.dashboardVisible === false ? 'Hidden from dashboard' : 'Visible in dashboard'}`,
+            dashboardVisible: codexStatus ? codexStatus.dashboardVisible !== false : true,
           });
         });
         return items;
@@ -9365,6 +9370,8 @@ async function fetchMenubarProviders() {
   }
 
   if (codexStatus) {
+    // Last resort when profiles API is unavailable; backend also accepts bare
+    // "codex" as matching any codex:N card.
     items.push({
       key: 'codex',
       name: codexStatus.name || 'Codex',


### PR DESCRIPTION
## Summary

After reordering providers in **Dashboard → Settings → Menubar**, **Codex disappeared** from the menubar popover.

## Root cause

| Surface | Codex ID |
|---|---|
| Menubar cards / snapshot | always account-scoped: `codex:1` |
| Web Settings list (single account) | bare: `codex` |

Saving order/visibility wrote `visible_providers: ["codex", ...]`.  
`filterMenubarProviders` did **exact** ID match → `codex:1` not allowed → card dropped.

Empty `visible_providers` (show all) hid the bug until Show/Hide or re-save after reorder.

## Fix

1. **Backend**: bare base keys (`codex`, `minimax`) match account-scoped cards (`codex:N`) in filter, sort, and options visibility; distinct accounts still do not match each other.
2. **Frontend**: when Codex profiles exist (including a single profile), always use `codex:<id>` in the menubar settings list so future saves align with card IDs.

## Test plan

- [x] `go test ./internal/web -run 'MenubarProviderKeys|FilterMenubar|SortProviderCards'`
- [x] Branch based on upstream `main`, single fix commit
- [ ] Live: Settings → Menubar reorder + Show/Hide; Codex remains in menubar

## Related

Menubar multi-account IDs (`codex:N`, `minimax:N`) vs settings base keys.