### PR TITLE
fix(web): emit resetsAt/timeUntilReset for Grok (menubar reset line)

### DIFF
--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -1896,7 +1896,14 @@ func (h *Handler) buildGrokCurrent() map[string]interface{} {
 			"status":      q.Status,
 		}
 		if q.ResetsAt != nil {
-			qm["resets_at"] = q.ResetsAt.Format(time.RFC3339)
+			// CamelCase fields match menubar normalizeQuotas + other providers;
+			// snake_case kept for dashboard renderGrokQuotaCards compatibility.
+			timeUntilReset := time.Until(*q.ResetsAt)
+			resetStr := q.ResetsAt.Format(time.RFC3339)
+			qm["resetsAt"] = resetStr
+			qm["resets_at"] = resetStr
+			qm["timeUntilReset"] = formatDuration(timeUntilReset)
+			qm["timeUntilResetSeconds"] = int64(timeUntilReset.Seconds())
 		}
 		quotas = append(quotas, qm)
 	}
@@ -1915,16 +1922,21 @@ func (h *Handler) buildGrokCurrent() map[string]interface{} {
 			primary := latest.Quotas[0]
 			sum := h.grokTracker.GetGrokSummary(store.DefaultGrokAccountID, primary.Name, latest)
 			if sum != nil {
-				response["summary"] = map[string]interface{}{
+				sm := map[string]interface{}{
 					"current_util":     sum.CurrentUtil,
-					"resets_at":        nil,
 					"current_rate":     sum.CurrentRate,
 					"projected_util":   sum.ProjectedUtil,
 					"completed_cycles": sum.CompletedCycles,
 				}
 				if sum.ResetsAt != nil {
-					(response["summary"].(map[string]interface{}))["resets_at"] = sum.ResetsAt.Format(time.RFC3339)
+					timeUntilReset := time.Until(*sum.ResetsAt)
+					resetStr := sum.ResetsAt.Format(time.RFC3339)
+					sm["resetsAt"] = resetStr
+					sm["resets_at"] = resetStr
+					sm["timeUntilReset"] = formatDuration(timeUntilReset)
+					sm["timeUntilResetSeconds"] = int64(timeUntilReset.Seconds())
 				}
+				response["summary"] = sm
 			}
 		}
 	}

--- a/internal/web/menubar_test.go
+++ b/internal/web/menubar_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/onllm-dev/onwatch/v2/internal/api"
+	"github.com/onllm-dev/onwatch/v2/internal/config"
 	"github.com/onllm-dev/onwatch/v2/internal/menubar"
 	"github.com/onllm-dev/onwatch/v2/internal/store"
 	"github.com/onllm-dev/onwatch/v2/internal/tracker"
@@ -655,3 +656,51 @@ func quotaLabels(quotas []menubar.QuotaMeter) []string {
 	}
 	return labels
 }
+
+func TestBuildMenubarSnapshotGrokResetFields(t *testing.T) {
+	s, err := store.New(":memory:")
+	if err != nil {
+		t.Fatalf("store.New: %v", err)
+	}
+	defer s.Close()
+
+	reset := time.Now().UTC().Add(3 * time.Hour).Truncate(time.Second)
+	capturedAt := time.Now().UTC().Truncate(time.Second)
+
+	if _, err := s.InsertGrokSnapshot(&api.GrokSnapshot{
+		CapturedAt: capturedAt,
+		AccountID:  1,
+		Email:      "test@example.com",
+		Quotas: []api.GrokQuota{
+			{Name: "credits", Utilization: 15, ResetsAt: &reset, Status: "healthy"},
+		},
+	}); err != nil {
+		t.Fatalf("InsertGrokSnapshot: %v", err)
+	}
+
+	cfg := &config.Config{
+		GrokEnabled:  true,
+		GrokToken:    "grok-test",
+		PollInterval: 60 * time.Second,
+		Port:         9211,
+		AdminUser:    "admin",
+		AdminPass:    "test",
+	}
+	h := NewHandler(s, nil, nil, nil, cfg)
+	snapshot, err := h.BuildMenubarSnapshot()
+	if err != nil {
+		t.Fatalf("BuildMenubarSnapshot: %v", err)
+	}
+
+	grok := findMenubarProviderCard(t, snapshot, "grok")
+	if len(grok.Quotas) == 0 {
+		t.Fatal("expected grok quotas")
+	}
+	if grok.Quotas[0].ResetAt == "" {
+		t.Fatalf("grok reset_at empty: %#v", grok.Quotas[0])
+	}
+	if grok.Quotas[0].TimeUntilReset == "" {
+		t.Fatalf("grok time_until_reset empty: %#v", grok.Quotas[0])
+	}
+}
+


### PR DESCRIPTION
## Summary

Grok menubar cards showed no token/quota **reset countdown** (clock line empty), while Codex/Anthropic worked.

## Root cause

`buildGrokCurrent` only set:

```go
qm["resets_at"] = ...
```

Menubar `normalizeQuotas` only reads:

```go
firstString(..., "renewsAt", "resetsAt", "resetDate", "resetTime", "resetAt")
stringValue(..., "timeUntilReset")
```

So `reset_at` / `time_until_reset` on the menubar snapshot were always empty for Grok.

## Fix (option 2 — align provider payload)

Emit the same fields as Anthropic/Codex/Cursor:

- `resetsAt`
- `timeUntilReset` / `timeUntilResetSeconds`

Keep `resets_at` for dashboard `renderGrokQuotaCards` compatibility.

## Kimi Code

The same alignment is applied for **Kimi** on `yesme/onWatch@main` (Kimi is not on upstream `main` yet; see #88). Once Kimi lands upstream, that half of the fix can ship with it or as a follow-up.

## Test plan

- [x] `go test ./internal/web -run BuildMenubarSnapshotGrokResetFields`
- [x] Branch based on upstream `main`, single commit
- [ ] Live menubar: Grok Credits shows reset countdown like other providers