### PR TITLE
fix(menubar): stop popover flash by keeping WebView warm

### DIFF
--- a/internal/menubar/companion_darwin.go
+++ b/internal/menubar/companion_darwin.go
@@ -78,6 +78,11 @@ func (c *trayController) onReady() {
 		logger.Warn("native macOS menubar host unavailable, using browser fallback", "error", err)
 	} else {
 		c.popover = popover
+		// Warm the WebView so the first tray click does not flash a blank page
+		// while /menubar navigates. Subsequent opens reuse the loaded document.
+		if err := popover.Preload(c.menubarURL()); err != nil {
+			logger.Debug("menubar popover preload failed", "error", err)
+		}
 	}
 
 	dashboardItem := systray.AddMenuItem("Open Dashboard", "Open the local onWatch dashboard")

--- a/internal/menubar/frontend/menubar.js
+++ b/internal/menubar/frontend/menubar.js
@@ -333,28 +333,41 @@
   }
 
   let refreshTimer = null;
+  let lastSettings = null;
+
+  async function refreshSnapshot() {
+    const settings = lastSettings || (await bridge.getSettings()) || {};
+    lastSettings = settings;
+    try {
+      const snapshot = await bridge.getSnapshot();
+      render(snapshot, settings);
+    } catch (error) {
+      renderError(error);
+    }
+  }
 
   async function init() {
     const settings = await bridge.getSettings();
+    lastSettings = settings || {};
     try {
       const snapshot = await bridge.getSnapshot();
-      render(snapshot, settings || {});
-      const intervalSeconds = Number(settings && settings.refresh_seconds ? settings.refresh_seconds : 60);
+      render(snapshot, lastSettings);
+      const intervalSeconds = Number(lastSettings && lastSettings.refresh_seconds ? lastSettings.refresh_seconds : 60);
       if (refreshTimer) {
         clearInterval(refreshTimer);
       }
-      refreshTimer = setInterval(async () => {
-        try {
-          const nextSnapshot = await bridge.getSnapshot();
-          render(nextSnapshot, settings || {});
-        } catch (error) {
-          renderError(error);
-        }
+      refreshTimer = setInterval(() => {
+        refreshSnapshot();
       }, Math.max(intervalSeconds, 10) * 1000);
     } catch (error) {
       renderError(error);
     }
   }
+
+  // Called by the native popover host when re-opening a warm WebView (no full reload).
+  window.__onwatchMenubarRefresh = function () {
+    refreshSnapshot();
+  };
 
   document.addEventListener('DOMContentLoaded', init);
 }());

--- a/internal/menubar/popover_darwin.go
+++ b/internal/menubar/popover_darwin.go
@@ -14,6 +14,9 @@ var errNativePopoverUnavailable = errors.New("native macOS menubar host unavaila
 type menubarPopover interface {
 	ShowURL(string) error
 	ToggleURL(string) error
+	// Preload warms the WebView document without showing the panel.
+	// Optional: implementations may no-op if preload is unsupported.
+	Preload(string) error
 	Close()
 	Destroy()
 }

--- a/internal/menubar/popover_darwin.m
+++ b/internal/menubar/popover_darwin.m
@@ -35,11 +35,13 @@ static void onwatch_run_on_main_sync(dispatch_block_t block) {
 @property(nonatomic, strong) id globalMouseMonitor;
 @property(nonatomic, strong) id localMouseMonitor;
 @property(nonatomic, strong) id appDeactivationObserver;
+@property(nonatomic, copy) NSString *loadedURLString;
 @property(nonatomic, assign) CGFloat width;
 @property(nonatomic, assign) CGFloat height;
 - (instancetype)initWithWidth:(CGFloat)width height:(CGFloat)height;
 - (void)applyHeight:(CGFloat)height;
 - (void)loadURLString:(NSString *)urlString;
+- (void)softRefreshIfLoaded;
 - (BOOL)show;
 - (BOOL)toggle;
 - (void)close;
@@ -307,8 +309,26 @@ static void onwatch_run_on_main_sync(dispatch_block_t block) {
   return [host isEqualToString:@"localhost"] || [host isEqualToString:@"127.0.0.1"];
 }
 
+- (void)softRefreshIfLoaded {
+  // Ask the warm page to re-fetch snapshot without a full document navigation.
+  // Full reloads on every open were the main cause of the popover flash.
+  if (!self.loadedURLString.length || !self.webView) {
+    return;
+  }
+  [self.webView evaluateJavaScript:@"window.__onwatchMenubarRefresh && window.__onwatchMenubarRefresh()"
+                 completionHandler:nil];
+}
+
 - (void)loadURLString:(NSString *)urlString {
   if (!urlString.length) {
+    return;
+  }
+
+  // Keep the WKWebView document warm. Re-loading on every open paints a blank
+  // shell first (flash), then re-inits JS. Same URL → skip navigation (soft
+  // refresh happens in -show so the panel never opens onto a reloading page).
+  if (self.loadedURLString.length && [self.loadedURLString isEqualToString:urlString] &&
+      self.webView.URL != nil) {
     return;
   }
 
@@ -317,7 +337,10 @@ static void onwatch_run_on_main_sync(dispatch_block_t block) {
     return;
   }
 
-  NSURLRequest *request = [NSURLRequest requestWithURL:url];
+  self.loadedURLString = [urlString copy];
+  NSURLRequest *request = [NSURLRequest requestWithURL:url
+                                           cachePolicy:NSURLRequestUseProtocolCachePolicy
+                                       timeoutInterval:30.0];
   [self.webView loadRequest:request];
 }
 
@@ -332,6 +355,10 @@ static void onwatch_run_on_main_sync(dispatch_block_t block) {
   }
 
   if (![self isShown]) {
+    // Soft-refresh after the panel is on screen so we never show a blank reload.
+    if (self.loadedURLString.length && self.webView.URL != nil) {
+      [self softRefreshIfLoaded];
+    }
     [self.panel makeKeyAndOrderFront:nil];
   }
   [self startTransientCloseMonitoring];

--- a/internal/menubar/webview_darwin.go
+++ b/internal/menubar/webview_darwin.go
@@ -25,7 +25,8 @@ import (
 )
 
 type webViewPopover struct {
-	handle unsafe.Pointer
+	handle    unsafe.Pointer
+	loadedURL string
 }
 
 func cBool(value C.bool) bool {
@@ -51,6 +52,8 @@ func (p *webViewPopover) ShowURL(url string) error {
 }
 
 func (p *webViewPopover) ToggleURL(url string) error {
+	// Always ensure the document is warm (no-op reload when URL already loaded),
+	// then toggle visibility. Avoids the blank-shell flash of a full navigation.
 	if !p.isShown() {
 		if err := p.loadURL(url); err != nil {
 			return err
@@ -60,6 +63,11 @@ func (p *webViewPopover) ToggleURL(url string) error {
 		return fmt.Errorf("%w: status item unavailable", errNativePopoverUnavailable)
 	}
 	return nil
+}
+
+// Preload warms the popover WebView without showing it.
+func (p *webViewPopover) Preload(url string) error {
+	return p.loadURL(url)
 }
 
 func (p *webViewPopover) Close() {
@@ -84,6 +92,7 @@ func (p *webViewPopover) loadURL(url string) error {
 	rawURL := C.CString(url)
 	defer C.free(unsafe.Pointer(rawURL))
 	C.onwatch_popover_load_url(p.handle, rawURL)
+	p.loadedURL = url
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Opening the macOS tray popover reloaded `/menubar` on every click, so WKWebView briefly showed a blank shell before the page re-initialized (visible flash).

## Fix

- **Preload** the menubar page when the companion starts
- **Skip full navigation** when the same URL is already loaded
- **Soft-refresh** snapshot data via JS (`window.__onwatchMenubarRefresh`) when reopening

## Test plan

- [x] Click tray icon to open popover — no blank-page flash
- [x] Close and reopen — content stays warm; data still updates
- [x] First open after menubar start still works (preload path)
- [x] Dashboard open / quit still work from tray menu