### PR TITLE
feat(settings): add Auto refresh tokens toggle (default on)

### DIFF
--- a/internal/agent/anthropic_agent.go
+++ b/internal/agent/anthropic_agent.go
@@ -241,12 +241,24 @@ func rateLimitBackoff(failCount int) time.Duration {
 	return backoff
 }
 
+// autoRefreshAllowed reports whether OAuth refresh-and-write is enabled in settings.
+func (a *AnthropicAgent) autoRefreshAllowed() bool {
+	if a.store == nil {
+		return true
+	}
+	return a.store.AutoRefreshTokensEnabled()
+}
+
 // proactiveRefresh attempts to refresh the OAuth token before it expires.
 // Respects rate limit backoff to avoid burning refresh tokens.
 // Skips proactive refresh if Claude Code is running to avoid competing for the
 // same refresh token (onWatch refreshes would invalidate Claude Code's pending
 // refresh and cause re-authentication).
 func (a *AnthropicAgent) proactiveRefresh(ctx context.Context, creds *api.AnthropicCredentials) {
+	if !a.autoRefreshAllowed() {
+		a.logger.Debug("Skipping proactive OAuth refresh - auto_refresh_tokens disabled")
+		return
+	}
 	// Skip if Claude Code is running - avoid competing for the same refresh token.
 	// onWatch refreshing burns Claude Code's scheduled refresh, causing invalid_grant.
 	checkFn := IsClaudeCodeRunning // package-level default
@@ -456,6 +468,10 @@ func (a *AnthropicAgent) poll(ctx context.Context) {
 
 			// Try to refresh token to get fresh rate limit window.
 			// Skip if Claude Code is running - refreshing burns CC's token.
+			if !a.autoRefreshAllowed() {
+				a.logger.Debug("Skipping 429 bypass refresh - auto_refresh_tokens disabled")
+				return
+			}
 			checkFn := IsClaudeCodeRunning
 			if a.isClaudeCodeRunning != nil {
 				checkFn = a.isClaudeCodeRunning

--- a/internal/agent/anthropic_ratelimit_test.go
+++ b/internal/agent/anthropic_ratelimit_test.go
@@ -427,14 +427,14 @@ func TestRateLimitBackoff_Calculation(t *testing.T) {
 		failCount int
 		want      time.Duration
 	}{
-		{0, rateLimitBaseBackoff},                  // 5m
-		{1, rateLimitBaseBackoff},                  // 5m * 2^0 = 5m
-		{2, rateLimitBaseBackoff * 2},              // 5m * 2^1 = 10m
-		{3, rateLimitBaseBackoff * 4},              // 5m * 2^2 = 20m
-		{4, rateLimitBaseBackoff * 8},              // 5m * 2^3 = 40m
-		{5, rateLimitBaseBackoff * 16},             // 5m * 2^4 = 80m
-		{10, rateLimitMaxBackoff},                  // capped at 6h
-		{20, rateLimitMaxBackoff},                  // still capped
+		{0, rateLimitBaseBackoff},      // 5m
+		{1, rateLimitBaseBackoff},      // 5m * 2^0 = 5m
+		{2, rateLimitBaseBackoff * 2},  // 5m * 2^1 = 10m
+		{3, rateLimitBaseBackoff * 4},  // 5m * 2^2 = 20m
+		{4, rateLimitBaseBackoff * 8},  // 5m * 2^3 = 40m
+		{5, rateLimitBaseBackoff * 16}, // 5m * 2^4 = 80m
+		{10, rateLimitMaxBackoff},      // capped at 6h
+		{20, rateLimitMaxBackoff},      // still capped
 	}
 	for _, tt := range tests {
 		got := rateLimitBackoff(tt.failCount)

--- a/internal/agent/anthropic_statusline.go
+++ b/internal/agent/anthropic_statusline.go
@@ -30,9 +30,9 @@ const statuslineFileName = "anthropic-statusline.json"
 // to the original command unchanged. No separate script files needed.
 //
 // How it works:
-//   1. Reads all of stdin into $I
-//   2. Saves $I to ~/.onwatch/data/anthropic-statusline.json (atomic via temp+mv)
-//   3. Pipes $I to stdout (so the next command in the pipe gets it)
+//  1. Reads all of stdin into $I
+//  2. Saves $I to ~/.onwatch/data/anthropic-statusline.json (atomic via temp+mv)
+//  3. Pipes $I to stdout (so the next command in the pipe gets it)
 const bridgeSnippet = `bash -c 'I=$(cat);D=$HOME/.onwatch/data;mkdir -p "$D" 2>/dev/null;T="$D/.sl-$$";printf "%s" "$I">"$T"&&mv -f "$T" "$D/anthropic-statusline.json" 2>/dev/null||rm -f "$T" 2>/dev/null;printf "%s" "$I"'`
 
 // bridgeMarker is a substring used to detect if the bridge snippet is already

--- a/internal/agent/anthropic_statusline_test.go
+++ b/internal/agent/anthropic_statusline_test.go
@@ -578,4 +578,3 @@ func TestEnsureStatuslineBridge_DetectsUserChange(t *testing.T) {
 		t.Errorf("expected user's new command preserved, got: %s", cmd)
 	}
 }
-

--- a/internal/agent/codex_agent.go
+++ b/internal/agent/codex_agent.go
@@ -324,67 +324,71 @@ func (a *CodexAgent) poll(ctx context.Context) {
 		if creds := a.credsRefresh(); creds != nil {
 			// Check if token is expiring soon or already expired
 			if creds.IsExpiringSoon(codexTokenRefreshThreshold) && creds.RefreshToken != "" {
-				a.logger.Info("Codex token expiring soon, attempting proactive OAuth refresh",
-					"expires_in", creds.ExpiresIn.Round(time.Second))
+				if a.store != nil && !a.store.AutoRefreshTokensEnabled() {
+					a.logger.Debug("Skipping Codex proactive OAuth refresh - auto_refresh_tokens disabled")
+				} else {
+					a.logger.Info("Codex token expiring soon, attempting proactive OAuth refresh",
+						"expires_in", creds.ExpiresIn.Round(time.Second))
 
-				newTokens, err := api.RefreshCodexToken(ctx, creds.RefreshToken)
-				if err != nil {
-					if errors.Is(err, api.ErrCodexRefreshTokenReused) {
-						// Unrecoverable - token is dead, user must re-authenticate
-						a.logger.Error("Codex refresh token already used - re-authenticate via 'codex auth'",
-							"error", err)
-						a.authPaused = true
-						a.lastFailedToken = creds.AccessToken
-						// Send auth error notification
-						a.sendAuthErrorNotification(
-							"Token Refresh Failed",
-							"Codex refresh token has been reused. Please re-authenticate via 'codex auth' to resume quota tracking.",
-							false, // not recoverable
-						)
-					} else {
-						a.proactiveRefreshFailures++
-						a.logger.Error("Proactive Codex OAuth refresh failed",
-							"error", err,
-							"consecutive_failures", a.proactiveRefreshFailures)
-						if a.proactiveRefreshFailures >= maxCodexAuthFailures {
+					newTokens, err := api.RefreshCodexToken(ctx, creds.RefreshToken)
+					if err != nil {
+						if errors.Is(err, api.ErrCodexRefreshTokenReused) {
+							// Unrecoverable - token is dead, user must re-authenticate
+							a.logger.Error("Codex refresh token already used - re-authenticate via 'codex auth'",
+								"error", err)
 							a.authPaused = true
 							a.lastFailedToken = creds.AccessToken
-							a.logger.Error("Codex proactive refresh PAUSED - too many consecutive failures",
-								"failure_count", a.proactiveRefreshFailures,
-								"action", "Re-authenticate via 'codex auth' to resume polling")
+							// Send auth error notification
 							a.sendAuthErrorNotification(
 								"Token Refresh Failed",
-								fmt.Sprintf("Codex proactive OAuth refresh failed %d times. Please re-authenticate via 'codex auth' to resume.", a.proactiveRefreshFailures),
-								false,
+								"Codex refresh token has been reused. Please re-authenticate via 'codex auth' to resume quota tracking.",
+								false, // not recoverable
 							)
+						} else {
+							a.proactiveRefreshFailures++
+							a.logger.Error("Proactive Codex OAuth refresh failed",
+								"error", err,
+								"consecutive_failures", a.proactiveRefreshFailures)
+							if a.proactiveRefreshFailures >= maxCodexAuthFailures {
+								a.authPaused = true
+								a.lastFailedToken = creds.AccessToken
+								a.logger.Error("Codex proactive refresh PAUSED - too many consecutive failures",
+									"failure_count", a.proactiveRefreshFailures,
+									"action", "Re-authenticate via 'codex auth' to resume polling")
+								a.sendAuthErrorNotification(
+									"Token Refresh Failed",
+									fmt.Sprintf("Codex proactive OAuth refresh failed %d times. Please re-authenticate via 'codex auth' to resume.", a.proactiveRefreshFailures),
+									false,
+								)
+							}
 						}
-					}
-				} else {
-					// Proactive refresh succeeded - reset failure counter
-					a.proactiveRefreshFailures = 0
-
-					// CRITICAL: Save new tokens to disk IMMEDIATELY (refresh tokens are one-time use!)
-					saveFn := a.tokenSave
-					if saveFn == nil {
-						saveFn = api.WriteCodexCredentials // fallback for backward compat
-					}
-					if err := saveFn(newTokens.AccessToken, newTokens.RefreshToken, newTokens.IDToken, newTokens.ExpiresIn); err != nil {
-						a.logger.Error("Failed to save refreshed Codex credentials", "error", err)
 					} else {
-						a.client.SetToken(newTokens.AccessToken)
-						a.lastToken = newTokens.AccessToken
-						a.logger.Info("Proactively refreshed Codex OAuth token",
-							"expires_in_hours", newTokens.ExpiresIn/3600)
+						// Proactive refresh succeeded - reset failure counter
+						a.proactiveRefreshFailures = 0
 
-						// Reset auth failures since we have fresh credentials
-						if a.authPaused {
-							a.authPaused = false
-							a.authFailCount = 0
-							a.lastFailedToken = ""
-							a.logger.Info("Codex auth failure pause lifted - token refreshed via OAuth")
+						// CRITICAL: Save new tokens to disk IMMEDIATELY (refresh tokens are one-time use!)
+						saveFn := a.tokenSave
+						if saveFn == nil {
+							saveFn = api.WriteCodexCredentials // fallback for backward compat
+						}
+						if err := saveFn(newTokens.AccessToken, newTokens.RefreshToken, newTokens.IDToken, newTokens.ExpiresIn); err != nil {
+							a.logger.Error("Failed to save refreshed Codex credentials", "error", err)
+						} else {
+							a.client.SetToken(newTokens.AccessToken)
+							a.lastToken = newTokens.AccessToken
+							a.logger.Info("Proactively refreshed Codex OAuth token",
+								"expires_in_hours", newTokens.ExpiresIn/3600)
+
+							// Reset auth failures since we have fresh credentials
+							if a.authPaused {
+								a.authPaused = false
+								a.authFailCount = 0
+								a.lastFailedToken = ""
+								a.logger.Info("Codex auth failure pause lifted - token refreshed via OAuth")
+							}
 						}
 					}
-				}
+				} // end auto_refresh_tokens enabled
 			}
 		}
 	}

--- a/internal/agent/cursor_agent.go
+++ b/internal/agent/cursor_agent.go
@@ -121,8 +121,12 @@ func (a *CursorAgent) poll(ctx context.Context) {
 	if a.credentialsRefresh != nil {
 		creds := a.credentialsRefresh()
 		if creds != nil && api.NeedsCursorRefresh(creds) && creds.RefreshToken != "" {
-			a.logger.Info("Cursor token expiring soon, refreshing", "expires_in", creds.ExpiresIn.Round(time.Minute))
-			refreshedThisPoll = a.refreshToken(ctx, creds.RefreshToken)
+			if a.store != nil && !a.store.AutoRefreshTokensEnabled() {
+				a.logger.Debug("Skipping Cursor OAuth refresh - auto_refresh_tokens disabled")
+			} else {
+				a.logger.Info("Cursor token expiring soon, refreshing", "expires_in", creds.ExpiresIn.Round(time.Minute))
+				refreshedThisPoll = a.refreshToken(ctx, creds.RefreshToken)
+			}
 		}
 	}
 
@@ -149,7 +153,7 @@ func (a *CursorAgent) poll(ctx context.Context) {
 			)
 
 			if a.authFailCount >= cursorMaxAuthFailures {
-				if a.credentialsRefresh != nil {
+				if a.credentialsRefresh != nil && (a.store == nil || a.store.AutoRefreshTokensEnabled()) {
 					creds := a.credentialsRefresh()
 					if creds != nil && creds.RefreshToken != "" {
 						a.logger.Info("Cursor: attempting token refresh due to auth failure")

--- a/internal/agent/gemini_agent.go
+++ b/internal/agent/gemini_agent.go
@@ -134,34 +134,38 @@ func (a *GeminiAgent) poll(ctx context.Context) {
 	if a.credsRefresh != nil && a.clientCreds != nil {
 		if creds := a.credsRefresh(); creds != nil {
 			if creds.IsExpiringSoon(geminiTokenRefreshThreshold) && creds.RefreshToken != "" {
-				a.logger.Info("Gemini token expiring soon, attempting proactive OAuth refresh",
-					"expires_in", creds.ExpiresIn.Round(time.Second))
-
-				newTokens, err := api.RefreshGeminiToken(ctx,
-					creds.RefreshToken,
-					a.clientCreds.ClientID,
-					a.clientCreds.ClientSecret,
-				)
-				if err != nil {
-					a.logger.Error("Proactive Gemini OAuth refresh failed", "error", err)
+				if a.store != nil && !a.store.AutoRefreshTokensEnabled() {
+					a.logger.Debug("Skipping Gemini proactive OAuth refresh - auto_refresh_tokens disabled")
 				} else {
-					// Save to file (local users)
-					if err := api.WriteGeminiCredentials(newTokens.AccessToken, newTokens.ExpiresIn); err != nil {
-						a.logger.Debug("Failed to save Gemini credentials to file", "error", err)
-					}
-					// Save to DB (survives Docker container restarts)
-					a.saveTokensToDB(newTokens.AccessToken, creds.RefreshToken, newTokens.ExpiresIn)
+					a.logger.Info("Gemini token expiring soon, attempting proactive OAuth refresh",
+						"expires_in", creds.ExpiresIn.Round(time.Second))
 
-					a.client.SetToken(newTokens.AccessToken)
-					a.lastToken = newTokens.AccessToken
-					a.logger.Info("Proactively refreshed Gemini OAuth token",
-						"expires_in_seconds", newTokens.ExpiresIn)
+					newTokens, err := api.RefreshGeminiToken(ctx,
+						creds.RefreshToken,
+						a.clientCreds.ClientID,
+						a.clientCreds.ClientSecret,
+					)
+					if err != nil {
+						a.logger.Error("Proactive Gemini OAuth refresh failed", "error", err)
+					} else {
+						// Save to file (local users)
+						if err := api.WriteGeminiCredentials(newTokens.AccessToken, newTokens.ExpiresIn); err != nil {
+							a.logger.Debug("Failed to save Gemini credentials to file", "error", err)
+						}
+						// Save to DB (survives Docker container restarts)
+						a.saveTokensToDB(newTokens.AccessToken, creds.RefreshToken, newTokens.ExpiresIn)
 
-					if a.authPaused {
-						a.authPaused = false
-						a.authFailCount = 0
-						a.lastFailedToken = ""
-						a.logger.Info("Gemini auth failure pause lifted - token refreshed via OAuth")
+						a.client.SetToken(newTokens.AccessToken)
+						a.lastToken = newTokens.AccessToken
+						a.logger.Info("Proactively refreshed Gemini OAuth token",
+							"expires_in_seconds", newTokens.ExpiresIn)
+
+						if a.authPaused {
+							a.authPaused = false
+							a.authFailCount = 0
+							a.lastFailedToken = ""
+							a.logger.Info("Gemini auth failure pause lifted - token refreshed via OAuth")
+						}
 					}
 				}
 			}
@@ -212,6 +216,10 @@ func (a *GeminiAgent) poll(ctx context.Context) {
 		}
 
 		if isGeminiAuthError(err) && a.credsRefresh != nil && a.clientCreds != nil {
+			if a.store != nil && !a.store.AutoRefreshTokensEnabled() {
+				a.logger.Debug("Skipping Gemini auth-error OAuth refresh - auto_refresh_tokens disabled")
+				return
+			}
 			a.logger.Warn("Gemini auth error, attempting token refresh", "error", err)
 
 			if creds := a.credsRefresh(); creds != nil && creds.RefreshToken != "" {

--- a/internal/agent/minimax_agent_manager.go
+++ b/internal/agent/minimax_agent_manager.go
@@ -33,7 +33,7 @@ type MiniMaxAgentManager struct {
 	notifier            *notify.NotificationEngine
 	pollingCheck        func() bool                // Global MiniMax polling check
 	accountPollingCheck func(accountID int64) bool // Per-account polling check
-	region              string                      // Default region for API base URL
+	region              string                     // Default region for API base URL
 
 	mu        sync.RWMutex
 	instances map[int64]*MiniMaxAgentInstance // db account id -> instance

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1632,6 +1632,9 @@ func (s *Store) QuerySyntheticCycleOverview(groupBy string, limit int) ([]CycleO
 	return rows, nil
 }
 
+// Setting key for OAuth auto-refresh of coding-harness credentials.
+const SettingAutoRefreshTokens = "auto_refresh_tokens"
+
 // GetSetting returns the value for a setting key. Returns "" if not found.
 func (s *Store) GetSetting(key string) (string, error) {
 	var value string
@@ -1652,6 +1655,25 @@ func (s *Store) SetSetting(key, value string) error {
 		return fmt.Errorf("store.SetSetting: %w", err)
 	}
 	return nil
+}
+
+// AutoRefreshTokensEnabled reports whether onWatch may perform OAuth token
+// refresh and write tokens back to coding-harness credential stores.
+// Defaults to true when unset (backward-compatible with existing installs).
+func (s *Store) AutoRefreshTokensEnabled() bool {
+	if s == nil {
+		return true
+	}
+	val, err := s.GetSetting(SettingAutoRefreshTokens)
+	if err != nil || val == "" {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(val)) {
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return true
+	}
 }
 
 // GetMenubarSettings returns persisted menubar settings, falling back to defaults.

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -682,6 +682,41 @@ func TestStore_SetAndGetSetting(t *testing.T) {
 	}
 }
 
+func TestStore_AutoRefreshTokensEnabled_DefaultTrue(t *testing.T) {
+	t.Parallel()
+	if !(*Store)(nil).AutoRefreshTokensEnabled() {
+		t.Fatal("nil store should default to true")
+	}
+	s, err := New(":memory:")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	defer s.Close()
+	if !s.AutoRefreshTokensEnabled() {
+		t.Fatal("unset setting should default to true")
+	}
+	if err := s.SetSetting(SettingAutoRefreshTokens, "false"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if s.AutoRefreshTokensEnabled() {
+		t.Fatal("want false after setting false")
+	}
+	if err := s.SetSetting(SettingAutoRefreshTokens, "true"); err != nil {
+		t.Fatalf("SetSetting: %v", err)
+	}
+	if !s.AutoRefreshTokensEnabled() {
+		t.Fatal("want true after setting true")
+	}
+	for _, off := range []string{"0", "no", "off", "FALSE"} {
+		if err := s.SetSetting(SettingAutoRefreshTokens, off); err != nil {
+			t.Fatalf("SetSetting(%q): %v", off, err)
+		}
+		if s.AutoRefreshTokensEnabled() {
+			t.Fatalf("want false for %q", off)
+		}
+	}
+}
+
 func TestStore_QuerySyntheticCycleOverview_NoCycles(t *testing.T) {
 	t.Parallel()
 	s, err := New(":memory:")

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -6240,10 +6240,17 @@ func (h *Handler) GetSettings(w http.ResponseWriter, r *http.Request) {
 		hiddenInsights = []string{}
 	}
 
+	// OAuth auto-refresh: default true when unset
+	autoRefreshTokens := true
+	if h.store != nil {
+		autoRefreshTokens = h.store.AutoRefreshTokensEnabled()
+	}
+
 	result := map[string]interface{}{
-		"timezone":        tz,
-		"hidden_insights": hiddenInsights,
-		"menubar":         menubarSettings,
+		"timezone":            tz,
+		"hidden_insights":     hiddenInsights,
+		"menubar":             menubarSettings,
+		"auto_refresh_tokens": autoRefreshTokens,
 	}
 
 	// SMTP settings (never return the actual password)
@@ -6353,6 +6360,25 @@ func (h *Handler) UpdateSettings(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		result["timezone"] = tz
+	}
+
+	// Handle auto_refresh_tokens (OAuth refresh of coding-harness credentials)
+	if raw, ok := body["auto_refresh_tokens"]; ok {
+		var enabled bool
+		if err := json.Unmarshal(raw, &enabled); err != nil {
+			respondError(w, http.StatusBadRequest, "invalid auto_refresh_tokens value")
+			return
+		}
+		val := "true"
+		if !enabled {
+			val = "false"
+		}
+		if err := h.store.SetSetting(store.SettingAutoRefreshTokens, val); err != nil {
+			h.logger.Error("failed to save auto_refresh_tokens setting", "error", err)
+			respondError(w, http.StatusInternalServerError, "failed to save setting")
+			return
+		}
+		result["auto_refresh_tokens"] = enabled
 	}
 
 	// Handle hidden_insights

--- a/internal/web/handlers_test.go
+++ b/internal/web/handlers_test.go
@@ -3587,6 +3587,53 @@ func TestHandler_UpdateSettings_Timezone(t *testing.T) {
 	}
 }
 
+func TestHandler_AutoRefreshTokensSetting(t *testing.T) {
+	t.Parallel()
+	s, _ := store.New(":memory:")
+	defer s.Close()
+
+	cfg := createTestConfigWithSynthetic()
+	h := NewHandler(s, nil, nil, nil, cfg)
+
+	// Default: enabled
+	req := httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rr := httptest.NewRecorder()
+	h.GetSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("GET status %d", rr.Code)
+	}
+	var got map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got["auto_refresh_tokens"] != true {
+		t.Fatalf("default auto_refresh_tokens = %v, want true", got["auto_refresh_tokens"])
+	}
+
+	// Disable
+	body := strings.NewReader(`{"auto_refresh_tokens":false}`)
+	req = httptest.NewRequest(http.MethodPut, "/api/settings", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr = httptest.NewRecorder()
+	h.UpdateSettings(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("PUT status %d body %s", rr.Code, rr.Body.String())
+	}
+	if s.AutoRefreshTokensEnabled() {
+		t.Fatal("store still reports enabled after false")
+	}
+
+	// GET reflects off
+	req = httptest.NewRequest(http.MethodGet, "/api/settings", nil)
+	rr = httptest.NewRecorder()
+	h.GetSettings(rr, req)
+	got = map[string]interface{}{}
+	_ = json.Unmarshal(rr.Body.Bytes(), &got)
+	if got["auto_refresh_tokens"] != false {
+		t.Fatalf("after disable auto_refresh_tokens = %v, want false", got["auto_refresh_tokens"])
+	}
+}
+
 func TestHandler_UpdateSettings_InvalidTimezone(t *testing.T) {
 	t.Parallel()
 	s, _ := store.New(":memory:")

--- a/internal/web/static/app.js
+++ b/internal/web/static/app.js
@@ -8878,6 +8878,12 @@ async function loadSettings() {
       updateBrowserDefaultTimezoneText();
     }
 
+    // Auto refresh OAuth tokens (default on)
+    const autoRefresh = document.getElementById('settings-auto-refresh-tokens');
+    if (autoRefresh) {
+      autoRefresh.checked = data.auto_refresh_tokens !== false;
+    }
+
     // SMTP
     if (data.smtp) {
       const s = data.smtp;
@@ -10327,6 +10333,12 @@ function gatherSettings() {
   const tzSelect = document.getElementById('settings-timezone');
   if (tzSelect) {
     settings.timezone = normalizeTz(tzSelect.value);
+  }
+
+  // Auto refresh OAuth tokens (coding harness credentials)
+  const autoRefresh = document.getElementById('settings-auto-refresh-tokens');
+  if (autoRefresh) {
+    settings.auto_refresh_tokens = !!autoRefresh.checked;
   }
 
   // Global display mode goes under provider_settings.global. Other provider

--- a/internal/web/templates/settings.html
+++ b/internal/web/templates/settings.html
@@ -302,6 +302,23 @@
         <!-- General Panel -->
         <div class="settings-panel" id="panel-general" role="tabpanel" hidden>
             <div class="settings-section">
+                <h3 class="settings-section-title">Credentials</h3>
+                <p class="settings-section-desc">Control how onWatch interacts with coding-harness OAuth tokens on disk (Claude Code, Kimi Code, Codex, etc.).</p>
+                <div class="settings-fields">
+                    <div class="settings-toggle-row">
+                        <div class="settings-toggle-info">
+                            <div class="settings-toggle-label">Auto refresh tokens</div>
+                            <div class="settings-toggle-sublabel">When enabled, onWatch may refresh OAuth tokens and write them back to harness credential files. Turn off if your CLI sessions keep expiring while onWatch is running.</div>
+                        </div>
+                        <label class="settings-toggle">
+                            <input type="checkbox" id="settings-auto-refresh-tokens" checked>
+                            <span class="settings-toggle-track"></span>
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <div class="settings-divider"></div>
+            <div class="settings-section">
                 <h3 class="settings-section-title">Timezone</h3>
                 <div class="settings-fields">
                     <div class="settings-field">


### PR DESCRIPTION
## Summary

Adds a **Settings → General → Auto refresh tokens** toggle (default **on**) so users can stop onWatch from performing OAuth refresh-and-write against coding-harness credential stores (Claude Code, Codex, Cursor, Gemini, etc.).

When disabled, onWatch still **reads** tokens from disk for polling, but will not call provider OAuth refresh endpoints or rewrite harness credential files. This reduces competition with long-lived CLI sessions that hold refresh tokens in memory (one-time refresh rotation can otherwise force re-login).

## Changes

- Persist `auto_refresh_tokens` in settings (`false` / unset→`true`)
- Expose via `GET/PUT /api/settings`
- Settings UI toggle with short explanation
- Gate OAuth refresh paths in Anthropic, Codex, Cursor, and Gemini agents

## Test plan

- [ ] Fresh install / unset setting: default remains enabled (existing behavior)
- [ ] Disable in Settings → Save; confirm DB `auto_refresh_tokens=false`
- [ ] With toggle off: no `Proactively refreshed` / `token refresh bypass` / credential write-back in logs
- [ ] With toggle off: still reloads tokens from disk when CLI rotates them
- [ ] Re-enable toggle restores proactive/auth-error refresh behavior
- [ ] `go test ./internal/store/ -run AutoRefresh` and `go test ./internal/web/ -run AutoRefreshTokens`