### PR TITLE
fix(antigravity): show 5h quota cards before Weekly

### DIFF
--- a/internal/api/antigravity_types.go
+++ b/internal/api/antigravity_types.go
@@ -324,15 +324,18 @@ type AntigravityQuotaSummaryResponse struct {
 
 // agyBucketMeta provides stable display ordering and colors for known buckets.
 // Unknown bucket IDs still render via parser fallbacks.
+//
+// Order prefers 5h buckets before weekly: the shorter window is usually hit
+// first, so it leads each family on the dashboard card strip.
 var agyBucketMeta = map[string]struct {
 	short string
 	color string
 	order int
 }{
-	"gemini-weekly": {"Gemini Weekly", "#10B981", 0},
-	"gemini-5h":     {"Gemini 5h", "#34D399", 1},
-	"3p-weekly":     {"Claude + GPT Weekly", "#D97757", 2},
-	"3p-5h":         {"Claude + GPT 5h", "#E8A38C", 3},
+	"gemini-5h":     {"Gemini 5h", "#34D399", 0},
+	"gemini-weekly": {"Gemini Weekly", "#10B981", 1},
+	"3p-5h":         {"Claude + GPT 5h", "#E8A38C", 2},
+	"3p-weekly":     {"Claude + GPT Weekly", "#D97757", 3},
 }
 
 // AgyBucketColor returns a stable card color for a bucket ID.

--- a/internal/api/antigravity_types_test.go
+++ b/internal/api/antigravity_types_test.go
@@ -28,6 +28,25 @@ func TestAntigravityDisplayName(t *testing.T) {
 	}
 }
 
+func TestAgyBucketOrder_5hBeforeWeekly(t *testing.T) {
+	if AgyBucketOrder("gemini-5h") >= AgyBucketOrder("gemini-weekly") {
+		t.Fatalf("gemini-5h order=%d should be before gemini-weekly order=%d",
+			AgyBucketOrder("gemini-5h"), AgyBucketOrder("gemini-weekly"))
+	}
+	if AgyBucketOrder("3p-5h") >= AgyBucketOrder("3p-weekly") {
+		t.Fatalf("3p-5h order=%d should be before 3p-weekly order=%d",
+			AgyBucketOrder("3p-5h"), AgyBucketOrder("3p-weekly"))
+	}
+	// Families stay grouped: both Gemini buckets before both Claude+GPT buckets.
+	if AgyBucketOrder("gemini-weekly") >= AgyBucketOrder("3p-5h") {
+		t.Fatalf("gemini-weekly order=%d should be before 3p-5h order=%d",
+			AgyBucketOrder("gemini-weekly"), AgyBucketOrder("3p-5h"))
+	}
+	if AgyBucketOrder("unknown-bucket") != 1000 {
+		t.Fatalf("unknown bucket order = %d, want 1000", AgyBucketOrder("unknown-bucket"))
+	}
+}
+
 func TestAntigravityUserStatusResponse_ActiveModelIDs(t *testing.T) {
 	resp := AntigravityUserStatusResponse{
 		UserStatus: &AntigravityUserStatus{


### PR DESCRIPTION
## Summary

Antigravity CLI quota cards put **Weekly** before **5h**. In normal use the 5-hour window is hit first, so this swaps display order via `AgyBucketOrder`:

1. Gemini 5h  
2. Gemini Weekly  
3. Claude + GPT 5h  
4. Claude + GPT Weekly  

## Test plan

- [x] Unit: `TestAgyBucketOrder_5hBeforeWeekly`
- [ ] Dashboard Antigravity tab (CLI): Gemini 5h left of Weekly; Claude+GPT 5h left of Weekly