### PR TITLE
test(grok): fix PreferredOIDC test expiry rot

### DIFF
--- a/internal/api/grok_credentials_test.go
+++ b/internal/api/grok_credentials_test.go
@@ -19,7 +19,7 @@ func TestParseGrokAuth_PreferredOIDC(t *testing.T) {
 			"user_id": "uid_789",
 			"first_name": "Jane",
 			"last_name": "Doe",
-			"expires_at": "2026-07-01T00:00:00Z"
+			"expires_at": "2099-01-01T00:00:00Z"
 		},
 		"https://accounts.x.ai/sign-in": {
 			"key": "legacy_tok",


### PR DESCRIPTION
`TestParseGrokAuth_PreferredOIDC` hardcoded `expires_at: 2026-07-01`, which is now a past date - `IsExpired()` flips to true and the test fails (`should not be expired`) on any run after that date. This made `internal/api` red on clean main independent of any feature work.

Fix: use `2099-01-01`, matching the never-expires convention already used by `TestDetectGrokCredentials_ValidFile` in the same file.

Verified: `go test ./internal/api/` is now fully green.