### PR TITLE
docs: clarify OpenCode workspace ID setup

### DIFF
--- a/docs/OPENCODE_SETUP.md
+++ b/docs/OPENCODE_SETUP.md
@@ -36,14 +36,36 @@ This is separate from `OPENCODE_ENABLED`, which only feeds ChatGPT credentials f
 
 ## 1. Find Your Workspace ID
 
-1. Open https://opencode.ai and sign in
-2. Open your OpenCode Go usage page. The URL looks like:
+Open https://opencode.ai and sign in, then use either method below.
+
+### From the browser URL
+
+Open your OpenCode Go usage page. The URL looks like:
 
 ```text
 https://opencode.ai/workspace/wrk_xxxxxxxx/go
 ```
 
-3. Copy the `wrk_...` segment. That is your `OPENCODE_GO_WORKSPACE_ID`.
+Copy the `wrk_...` segment. That is your `OPENCODE_GO_WORKSPACE_ID`.
+
+### From the authenticated Go page
+
+Copy the `auth` cookie value as described in the next section, then run:
+
+```bash
+curl -sS --compressed \
+  -H 'Cookie: auth=<your-auth-cookie-value>' \
+  https://opencode.ai/go |
+  grep -oE 'wrk_[A-Za-z0-9]+' |
+  sort -u
+```
+
+The authenticated `/go` page contains the workspace ID. The site root does not.
+`https://opencode.ai/zen` can also expose it, but `/go` is preferred for an
+OpenCode Go subscription.
+
+If the command returns multiple workspace IDs, use the one whose
+`https://opencode.ai/workspace/<workspace-id>/go` page shows your Go usage.
 
 ---
 


### PR DESCRIPTION
A small update the doc about Opencode installation.
Related to https://github.com/onllm-dev/onWatch/pull/109 and https://github.com/onllm-dev/onWatch/issues/100.

## Summary

Updates the OpenCode Go setup guide for issue #100.

- Adds the verified `/go` command for finding `OPENCODE_GO_WORKSPACE_ID`
- Explains that the site root does not expose the workspace ID
- Notes that `/zen` may also expose it
- Explains how to choose the correct workspace if multiple IDs are returned

## Validation

- `git diff --check` passed
- Documentation-only change