### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It works with any tool that uses Synthetic, Z.ai, Anthropic, Codex, GitHub Copil
 
 **Beta:** onWatch is currently in active development. Features and APIs may change as we refine the product.
 
-[![Star History Chart](https://api.star-history.com/svg?repos=onllm-dev/onwatch&type=Timeline)](https://star-history.com/#onllm-dev/onwatch&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=onllm-dev/onwatch&type=Timeline)](https://star-history.dera.page/#onllm-dev/onwatch&Timeline)
 
 ![Anthropic Dashboard - Light Mode](./docs/screenshots/anthropic-light.png)
 


### PR DESCRIPTION
The star history chart in the README stopped working, so the project's popularity graph no longer renders for visitors. This switches the chart to a working endpoint so it displays correctly again. Please merge this fix.